### PR TITLE
Convert priority to floats before transmitting

### DIFF
--- a/src/triggers/issue.ts
+++ b/src/triggers/issue.ts
@@ -80,7 +80,7 @@ const buildIssueList = (orderBy: "createdAt" | "updatedAt") => async (z: ZObject
         statusId: bundle.inputData.status_id,
         creatorId: bundle.inputData.creator_id,
         assigneeId: bundle.inputData.assignee_id,
-        priority: bundle.inputData.priority,
+        priority: parseFloat(bundle.inputData.priority),
         labelId: bundle.inputData.label_id,
         projectId: bundle.inputData.project_id,
 

--- a/src/triggers/issue.ts
+++ b/src/triggers/issue.ts
@@ -80,7 +80,7 @@ const buildIssueList = (orderBy: "createdAt" | "updatedAt") => async (z: ZObject
         statusId: bundle.inputData.status_id,
         creatorId: bundle.inputData.creator_id,
         assigneeId: bundle.inputData.assignee_id,
-        priority: parseFloat(bundle.inputData.priority),
+        priority: parseInt(bundle.inputData.priority),
         labelId: bundle.inputData.label_id,
         projectId: bundle.inputData.project_id,
 


### PR DESCRIPTION
Prior to making this change I was getting the following error in the logs when attempting to use priority in an issueCreated zap:

```
Catch error 400 {
  errors: [
    {
      message: 'Variable "$priority" got invalid value "1"; Float cannot represent non numeric value: "1"',
      locations: [Array],
      extensions: [Object]
    }
  ]
}
```