### PR TITLE
feat: added estimate configuration option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/creates/createIssue.ts
+++ b/src/creates/createIssue.ts
@@ -22,12 +22,14 @@ interface CreateIssueRequestResponse {
 
 const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
   const priority = bundle.inputData.priority ? parseInt(bundle.inputData.priority) : 0;
+  const estimate = bundle.inputData.estimate ? parseInt(bundle.inputData.estimate) : null;
 
   const variables = {
     teamId: bundle.inputData.team_id,
     title: bundle.inputData.title,
     description: bundle.inputData.description,
     priority: priority,
+    estimate: estimate,
     stateId: bundle.inputData.status_id,
     assigneeId: bundle.inputData.assignee_id,
     projectId: bundle.inputData.project_id,
@@ -40,6 +42,7 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
         $title: String!,
         $description: String,
         $priority: Int,
+        $estimate: Int,
         $stateId: String,
         $assigneeId: String,
         $projectId: String,
@@ -50,6 +53,7 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
           title: $title,
           description: $description,
           priority: $priority,
+          estimate: $estimate,
           stateId: $stateId,
           assigneeId: $assigneeId,
           projectId: $projectId,
@@ -157,6 +161,12 @@ export const createIssue = {
           { value: "3", sample: "3", label: "Medium" },
           { value: "4", sample: "4", label: "Low" },
         ],
+      },
+      {
+        label: "Estimate",
+        helpText: "Select this issue's estimate",
+        key: "estimate",
+        dynamic: "estimate.id.label",
       },
       {
         label: "Labels",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { user } from "./triggers/user";
 import { project } from "./triggers/project";
 import { HttpResponse, ZObject } from "zapier-platform-core";
 import { createComment } from "./creates/createComment";
+import { estimate } from "./triggers/estimate";
 
 const handleErrors = (response: HttpResponse, z: ZObject) => {
   if (response.request.url !== "https://api.linear.app/graphql") {
@@ -44,6 +45,7 @@ const App = {
     [project.key]: project,
     [label.key]: label,
     [user.key]: user,
+    [estimate.key]: estimate,
   },
   authentication,
   beforeRequest: [addBearerHeader],

--- a/src/triggers/estimate.ts
+++ b/src/triggers/estimate.ts
@@ -1,0 +1,146 @@
+import { ZObject, Bundle } from "zapier-platform-core";
+
+enum EstimationType {
+  /** Don't use estimates. */
+  notUsed = "notUsed",
+
+  /** 1, 2, 4, 8, 16. */
+  exponential = "exponential",
+
+  /** 1, 2, 3, 5, 8. */
+  fibonacci = "fibonacci",
+
+  /** 1, 2, 3, 4, 5. */
+  linear = "linear",
+
+  /** XS, S, M, L, XL. */
+  tShirt = "tShirt",
+}
+
+type TeamResponse ={
+  data: {
+    team: {
+      issueEstimationAllowZero: boolean;
+      issueEstimationExtended: boolean;
+      issueEstimationType: EstimationType;
+    };
+  };
+}
+
+const optionsForType = (type: EstimationType, allowZero: boolean, extended: boolean): {id: number, label: string}[] => {
+  const result = [];
+  if (allowZero) {
+    result.push(type === EstimationType.tShirt ? {id: 0, label: '-'} : {id: 0, label: '0 Points'})
+  }
+
+  switch (type) {
+    case EstimationType.notUsed:
+      return [];
+    case EstimationType.exponential:
+      return result.concat(
+        [
+          {id: 1, label: '1 Point'},
+          {id: 2, label: '2 Points'},
+          {id: 4, label: '4 Points'},
+          {id: 8, label: '8 Points'},
+          { id: 16, label: '16 Points'}
+        ]).concat(
+          extended ? [
+            { id: 32, label: '32 Points'},
+            { id: 64, label: '64 Points'}
+          ] : []
+        );
+    case EstimationType.fibonacci:
+      return result.concat(
+        [
+          {id: 1, label: '1 Point'},
+          {id: 2, label: '2 Points'},
+          {id: 3, label: '3 Points'},
+          {id: 5, label: '5 Points'},
+          {id: 8, label: '8 Points'},
+        ]).concat(
+          extended ? [
+            { id: 13, label: '13 Points'},
+            { id: 21, label: '21 Points'},
+          ] : []
+        );
+    case EstimationType.linear:
+      return result.concat(
+        [
+          {id: 1, label: '1 Point'},
+          {id: 2, label: '2 Points'},
+          {id: 3, label: '3 Points'},
+          {id: 4, label: '4 Points'},
+          {id: 5, label: '5 Points'},
+        ]).concat(
+          extended ? [
+            {id: 6, label: '6 Points'},
+            {id: 7, label: '7 Points'},
+          ] : []
+        );
+    case EstimationType.tShirt:
+      return result.concat(
+        [
+          {id: 1, label: 'XS'},
+          {id: 2, label: 'S'},
+          {id: 3, label: 'M'},
+          {id: 5, label: 'L'},
+          {id: 8, label: 'XL'},
+        ]).concat(
+          extended ? [
+            { id: 13, label: 'XXL'},
+            { id: 21, label: 'XXXL'},
+          ] : []
+        );
+    default:
+      return [];
+  }
+}
+
+const getEstimateOptions = async (z: ZObject, bundle: Bundle) => {
+  if (!bundle.inputData.team_id) {
+    throw new z.errors.HaltedError(`Please select the team first`);
+  }
+  const response = await z.request({
+    url: "https://api.linear.app/graphql",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      authorization: bundle.authData.api_key,
+    },
+    body: {
+      query: `
+      query ($teamId: String!) {
+        team(id: $teamId) {
+          issueEstimationAllowZero
+          issueEstimationExtended
+          issueEstimationType
+        }
+      }`,
+      variables: {
+        teamId: bundle.inputData.team_id,
+      },
+    },
+    method: "POST",
+  });
+
+  const data = (response.json as TeamResponse).data;
+  return optionsForType(data.team.issueEstimationType, data.team.issueEstimationAllowZero, data.team.issueEstimationExtended);
+};
+
+export const estimate = {
+  key: "estimate",
+  noun: "Estimate",
+
+  display: {
+    label: "Get issue estimate options",
+    hidden: true,
+    description:
+      "The only purpose of this trigger is to populate the dropdown list of issue estimates in the UI, thus, it's hidden.",
+  },
+
+  operation: {
+    perform: getEstimateOptions,
+    canPaginate: false,
+  },
+};


### PR DESCRIPTION
Added an option tp add estimates to issues. The app is now published at version 2.2.4, but is not promoted yet.

<img width="914" alt="image" src="https://user-images.githubusercontent.com/1820005/205592687-625da402-ba3a-4f7b-b08d-aea861915b97.png">

The options are loaded dynamically based on team's setting