### PR TITLE
feat: added project name to issue create payload

### DIFF
--- a/src/creates/createIssue.ts
+++ b/src/creates/createIssue.ts
@@ -8,6 +8,9 @@ interface CreateIssueRequestResponse {
         title: string;
         url: string;
         identifier: string;
+        project?: {
+          name?: string | null;
+        }
       };
       success: boolean;
     };
@@ -64,6 +67,9 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
             identifier
             title
             url
+            project {
+              name
+            }
           }
           success
         }


### PR DESCRIPTION
Added project name to issue creation response. Original Issue on GH (https://github.com/linear/linear-zapier/issues/24) also asked for creator id, but in this case creator id is null, because it was created by zapier. This information is stored in sourceMetadata, which we do not want to expose (i think).