### PR TITLE
Restore `creator` and `assignee` fields in issues trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/samples/issue.json
+++ b/src/samples/issue.json
@@ -7,6 +7,16 @@
   "priority": 0,
   "estimate": null,
   "dueDate": null,
-  "createdAt": "2020-10-27T21:20:59.199Z",
-  "updatedAt": "2020-10-27T21:20:59.199Z"
+  "createdAt": "2022-10-27T21:20:59.199Z",
+  "updatedAt": "2022-10-27T21:20:59.199Z",
+  "creator": {
+    "id": "df2b39ba-3dfd-4b75-9ce2-2be2d1c79a2b",
+    "name": "Zapier User",
+    "email": "creator@example.com"
+  },
+  "assignee": {
+    "id": "843e7b66-9d10-11ed-a8fc-0242ac120002",
+    "name": "Zapier User",
+    "email": "assignee@example.com"
+  }
 }

--- a/src/triggers/issue.ts
+++ b/src/triggers/issue.ts
@@ -16,6 +16,16 @@ interface TeamIssuesResponse {
           dueDate: Date;
           createdAt: Date;
           updatedAt: Date;
+          creator: {
+            id: string;
+            name: string;
+            email: string;
+          };
+          assignee?: {
+            id: string;
+            name: string;
+            email: string;
+          };
         }[];
       };
     };
@@ -70,6 +80,16 @@ const buildIssueList = (orderBy: "createdAt" | "updatedAt") => async (z: ZObject
               dueDate
               createdAt
               updatedAt
+              creator {
+                id
+                name
+                email
+              }
+              assignee {
+                id
+                name
+                email
+              }
             }
           }
         }
@@ -83,7 +103,6 @@ const buildIssueList = (orderBy: "createdAt" | "updatedAt") => async (z: ZObject
         priority: bundle.inputData.priority && Number(bundle.inputData.priority) || undefined,
         labelId: bundle.inputData.label_id,
         projectId: bundle.inputData.project_id,
-
         orderBy,
       },
     },


### PR DESCRIPTION
Originally many fields were removed to reduce load on our servers as Zapier polling was using more than it's fair share of resources, we're going to gradually add these back.