### PR TITLE
Restore project name in Zapier trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/samples/issue.json
+++ b/src/samples/issue.json
@@ -9,6 +9,10 @@
   "dueDate": null,
   "createdAt": "2022-10-27T21:20:59.199Z",
   "updatedAt": "2022-10-27T21:20:59.199Z",
+  "project": {
+    "id": "66913eff-e405-4d04-bd31-91678259f9e7",
+    "name": "My Project"
+  },
   "creator": {
     "id": "df2b39ba-3dfd-4b75-9ce2-2be2d1c79a2b",
     "name": "Zapier User",


### PR DESCRIPTION
- Restore project name in Zapier trigger
- Add pagination to issue trigger
- Reduce pagination limit to lower complexity load

![image](https://github.com/linear/linear-zapier/assets/380914/ac9bb60c-3e1a-498a-99fb-8e8b28a6be44)

closes #24 