### PR TITLE
feat: add additional filters for comments trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/triggers/comment.ts
+++ b/src/triggers/comment.ts
@@ -76,7 +76,6 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
         $creatorId: ID
         $teamId: ID
         $issueId: ID
-        $projectId: ID
       ) {
         comments(
           first: 25
@@ -86,7 +85,6 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
               { user: { id: { eq: $creatorId } } }
               { issue: { team: { id: { eq: $teamId } } } }
               { issue: { id: { eq: $issueId } } }
-              { project: { id: { eq: $projectId } } }
             ]
           }
         ) {
@@ -146,7 +144,6 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
         creatorId: bundle.inputData.creator_id,
         teamId: bundle.inputData.team_id,
         issueId: bundle.inputData.issue,
-        projectId: bundle.inputData.project,
         after: cursor,
       },
     },
@@ -194,12 +191,6 @@ const comment = {
         label: "Issue ID",
         key: "issue",
         helpText: "Only trigger on comments added to this issue identified by its ID (UUID or application ID).",
-      },
-      {
-        required: false,
-        label: "Project ID",
-        key: "project",
-        helpText: "Only triggers on comments added to this project (project update or document) identified by its ID.",
       },
     ],
     sample,

--- a/src/triggers/comment.ts
+++ b/src/triggers/comment.ts
@@ -49,6 +49,15 @@ interface CommentsResponse {
             id: string;
             name: string;
             url: string;
+          } | null;
+          document: {
+            id: string;
+            title: string;
+            project: {
+              id: string;
+              name: string;
+              url: string;
+            };
           };
         } | null;
         user: {
@@ -173,6 +182,15 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
                 id
                 name
                 url
+              }
+              document {
+                id
+                title
+                project {
+                  id
+                  name
+                  url
+                }
               }
             }
             user {

--- a/src/triggers/comment.ts
+++ b/src/triggers/comment.ts
@@ -57,17 +57,7 @@ interface CommentsResponse {
           name: string;
           avatarUrl: string;
         };
-        parent: {
-          id: string;
-          body: string;
-          createdAt: string;
-          user: {
-            id: string;
-            email: string;
-            name: string;
-            avatarUrl: string;
-          };
-        } | null;
+        parentId: string | null;
       }[];
       pageInfo: {
         hasNextPage: boolean;
@@ -181,17 +171,7 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
               name
               avatarUrl
             }
-            parent {
-              id
-              body
-              createdAt
-              user {
-                id
-                email
-                name
-                avatarUrl
-              }
-            }
+            parentId
           }
           pageInfo {
             hasNextPage

--- a/src/triggers/comment.ts
+++ b/src/triggers/comment.ts
@@ -57,7 +57,17 @@ interface CommentsResponse {
           name: string;
           avatarUrl: string;
         };
-        parentId: string | null;
+        parent: {
+          id: string;
+          body: string;
+          createdAt: string;
+          user: {
+            id: string;
+            email: string;
+            name: string;
+            avatarUrl: string;
+          };
+        } | null;
       }[];
       pageInfo: {
         hasNextPage: boolean;
@@ -171,7 +181,17 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
               name
               avatarUrl
             }
-            parentId
+            parent {
+              id
+              body
+              createdAt
+              user {
+                id
+                email
+                name
+                avatarUrl
+              }
+            }
           }
           pageInfo {
             hasNextPage

--- a/src/triggers/comment.ts
+++ b/src/triggers/comment.ts
@@ -9,7 +9,14 @@ interface CommentsResponse {
         body: string;
         url: string;
         createdAt: string;
-        issue?: {
+        resolvedAt: string | null;
+        resolvingUser: {
+          id: string;
+          name: string;
+          email: string;
+          avatarUrl: string;
+        } | null;
+        issue: {
           id: string;
           identifier: string;
           title: string;
@@ -19,7 +26,7 @@ interface CommentsResponse {
             name: string;
           };
         } | null;
-        projectUpdate?: {
+        projectUpdate: {
           id: string;
           body: string;
           user: {
@@ -35,7 +42,7 @@ interface CommentsResponse {
             url: string;
           };
         } | null;
-        documentContent?: {
+        documentContent: {
           id: string;
           content: string;
           project: {
@@ -50,6 +57,17 @@ interface CommentsResponse {
           name: string;
           avatarUrl: string;
         };
+        parent: {
+          id: string;
+          body: string;
+          createdAt: string;
+          user: {
+            id: string;
+            email: string;
+            name: string;
+            avatarUrl: string;
+          };
+        } | null;
       }[];
       pageInfo: {
         hasNextPage: boolean;
@@ -92,6 +110,13 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
             id
             body
             createdAt
+            resolvedAt
+            resolvingUser {
+              id
+              name
+              email
+              avatarUrl
+            }
             issue {
               id
               identifier
@@ -132,6 +157,17 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
               email
               name
               avatarUrl
+            }
+            parent {
+              id
+              body
+              createdAt
+              user {
+                id
+                email
+                name
+                avatarUrl
+              }
             }
           }
           pageInfo {
@@ -174,7 +210,7 @@ const comment = {
         required: false,
         label: "Team",
         key: "team_id",
-        helpText: "Only trigger on comments created to this team.",
+        helpText: "Only trigger on issue comments created to this team.",
         dynamic: "team.id.name",
         altersDynamicFields: true,
       },
@@ -182,7 +218,7 @@ const comment = {
         required: false,
         label: "Creator",
         key: "creator_id",
-        helpText: "Only trigger on comments added by this user.",
+        helpText: "Only trigger on comments (issue, project updates, document comments) added by this user.",
         dynamic: "user.id.name",
         altersDynamicFields: true,
       },

--- a/src/triggers/comment.ts
+++ b/src/triggers/comment.ts
@@ -9,7 +9,7 @@ interface CommentsResponse {
         body: string;
         url: string;
         createdAt: string;
-        issue: {
+        issue?: {
           id: string;
           identifier: string;
           title: string;
@@ -18,7 +18,32 @@ interface CommentsResponse {
             id: string;
             name: string;
           };
-        };
+        } | null;
+        projectUpdate?: {
+          id: string;
+          body: string;
+          user: {
+            id: string;
+            name: string;
+            email: string;
+            avatarUrl: string;
+          };
+          url: string;
+          project: {
+            id: string;
+            name: string;
+            url: string;
+          };
+        } | null;
+        documentContent?: {
+          id: string;
+          content: string;
+          project: {
+            id: string;
+            name: string;
+            url: string;
+          };
+        } | null;
         user: {
           id: string;
           email: string;
@@ -51,6 +76,7 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
         $creatorId: ID
         $teamId: ID
         $issueId: ID
+        $projectId: ID
       ) {
         comments(
           first: 25
@@ -60,6 +86,7 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
               { user: { id: { eq: $creatorId } } }
               { issue: { team: { id: { eq: $teamId } } } }
               { issue: { id: { eq: $issueId } } }
+              { project: { id: { eq: $projectId } } }
             ]
           }
         ) {
@@ -75,6 +102,31 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
               team {
                 id
                 name
+              }
+            }
+            projectUpdate {
+              id
+              body
+              user {
+                id
+                name
+                email
+                avatarUrl
+              }
+              url
+              project {
+                id
+                name
+                url
+              }
+            }
+            documentContent {
+              id
+              content
+              project {
+                id
+                name
+                url
               }
             }
             user {
@@ -94,7 +146,8 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
         creatorId: bundle.inputData.creator_id,
         teamId: bundle.inputData.team_id,
         issueId: bundle.inputData.issue,
-        after: cursor
+        projectId: bundle.inputData.project,
+        after: cursor,
       },
     },
     method: "POST",
@@ -141,6 +194,12 @@ const comment = {
         label: "Issue ID",
         key: "issue",
         helpText: "Only trigger on comments added to this issue identified by its ID (UUID or application ID).",
+      },
+      {
+        required: false,
+        label: "Project ID",
+        key: "project",
+        helpText: "Only triggers on comments added to this project (project update or document) identified by its ID.",
       },
     ],
     sample,


### PR DESCRIPTION
Comments trigger now returns comments for project updates and documents.

You can optionally specify `project_update_project_id` to limit returning only project update comments with a given project id.

Fixes EU-4599