### PR TITLE
Add REST trigger version of new document comment trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "2.15.0",
+  "version": "3.0.0",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { projectMilestone } from "./triggers/projectMilestone";
 import { HttpResponse, ZObject } from "zapier-platform-core";
 import { createComment } from "./creates/createComment";
 import { estimate } from "./triggers/estimate";
+import { newDocumentCommentV2 } from "./triggers/commentDocumentV2";
 
 const handleErrors = (response: HttpResponse, z: ZObject) => {
   if (response.request.url !== "https://api.linear.app/graphql") {
@@ -47,6 +48,7 @@ const App = {
     [newProjectUpdate.key]: newProjectUpdate,
     [newProjectUpdateComment.key]: newProjectUpdateComment,
     [newDocumentComment.key]: newDocumentComment,
+    [newDocumentCommentV2.key]: newDocumentCommentV2,
     [updatedProjectUpdate.key]: updatedProjectUpdate,
     [team.key]: team,
     [status.key]: status,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { projectMilestone } from "./triggers/projectMilestone";
 import { HttpResponse, ZObject } from "zapier-platform-core";
 import { createComment } from "./creates/createComment";
 import { estimate } from "./triggers/estimate";
-import { newDocumentCommentV2 } from "./triggers/commentDocumentV2";
+import { newDocumentCommentInstant } from "./triggers/commentDocumentV2";
 
 const handleErrors = (response: HttpResponse, z: ZObject) => {
   if (response.request.url !== "https://api.linear.app/graphql") {
@@ -48,7 +48,7 @@ const App = {
     [newProjectUpdate.key]: newProjectUpdate,
     [newProjectUpdateComment.key]: newProjectUpdateComment,
     [newDocumentComment.key]: newDocumentComment,
-    [newDocumentCommentV2.key]: newDocumentCommentV2,
+    [newDocumentCommentInstant.key]: newDocumentCommentInstant,
     [updatedProjectUpdate.key]: updatedProjectUpdate,
     [team.key]: team,
     [status.key]: status,

--- a/src/samples/documentComment.json
+++ b/src/samples/documentComment.json
@@ -5,7 +5,6 @@
   "resolvedAt": null,
   "resolvingUser": null,
   "documentContent": {
-    "id": "c4012402-d0c7-4c2f-aeef-ff660fa7c952",
     "createdAt": "2023-09-29T18:07:35.001Z",
     "updatedAt": "2024-01-11T16:56:47.539Z",
     "project": {

--- a/src/triggers/commentDocument.ts
+++ b/src/triggers/commentDocument.ts
@@ -64,12 +64,15 @@ interface CommentsResponse {
 const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
   const cursor = bundle.meta.page ? await z.cursor.get() : undefined;
 
-  const variables = omitBy({
-    creatorId: bundle.inputData.creator_id,
-    projectId: bundle.inputData.project_id,
-    documentId: bundle.inputData.document_id,
-    after: cursor,
-  }, v => v === undefined);
+  const variables = omitBy(
+    {
+      creatorId: bundle.inputData.creator_id,
+      projectId: bundle.inputData.project_id,
+      documentId: bundle.inputData.document_id,
+      after: cursor,
+    },
+    (v) => v === undefined
+  );
 
   const filters = [];
   if ("creatorId" in variables) {
@@ -101,12 +104,16 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
         comments(
           first: 25
           after: $after
-          ${filters.length > 0 ?`
+          ${
+            filters.length > 0
+              ? `
           filter: {
             and : [
               ${filters.join("\n              ")}
             ]
-          }` : ""}
+          }`
+              : ""
+          }
         ) {
           nodes {
             id
@@ -218,6 +225,7 @@ export const newDocumentComment = {
   display: {
     label: "New Document Comment",
     description: "Triggers when a new document comment is created.",
+    hidden: true,
   },
   operation: {
     ...comment.operation,

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -249,10 +249,9 @@ export const newDocumentCommentV2 = {
     performUnsubscribe: unsubscribeHook,
     perform: getComment,
     performList: getCommentList(),
-    outputFields: [
-      { key: "id", label: "ID" },
-      { key: "body", label: "Body" },
-    ],
+    outputFields: () => {
+      return [];
+    },
     sample,
   },
 };

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -249,7 +249,6 @@ export const newDocumentCommentV2 = {
     performUnsubscribe: unsubscribeHook,
     perform: getComment,
     performList: getCommentList(),
-    outputFields: [],
     sample,
   },
 };

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -224,7 +224,7 @@ export const newDocumentCommentV2 = {
   key: "newDocumentCommentV2",
   noun: "Comment",
   display: {
-    label: "New Document Comment V2",
+    label: "New Document Comment",
     description: "Triggers when a new document comment is created.",
   },
   operation: {

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -214,7 +214,7 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
   return data.comments.nodes;
 };
 
-export const newDocumentCommentV2 = {
+export const newDocumentCommentInstant = {
   key: "newDocumentCommentV2",
   noun: "Comment",
   display: {

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -120,7 +120,7 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
     (v: undefined) => v === undefined
   );
 
-  const filters = [];
+  const filters = [` { and: [{ documentContent: { null: false } }] }`];
   if ("creatorId" in variables) {
     filters.push(`{ user: { id: { eq: $creatorId } } }`);
   }

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -113,9 +113,9 @@ const getComment = (z: ZObject, bundle: Bundle) => {
 const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
   const variables = omitBy(
     {
-      creatorId: bundle.inputData.creator_id,
-      projectId: bundle.inputData.project_id,
-      documentId: bundle.inputData.document_id,
+      creatorId: bundle.inputData.creatorId,
+      projectId: bundle.inputData.projectId,
+      documentId: bundle.inputData.documentId,
     },
     (v: undefined) => v === undefined
   );

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -1,0 +1,264 @@
+import { omitBy, pick } from "lodash";
+import { ZObject, Bundle } from "zapier-platform-core";
+import sample from "../samples/projectUpdateComment.json";
+
+interface Comment {
+  id: string;
+  body: string;
+  url: string;
+  createdAt: string;
+  resolvedAt: string | null;
+  documentContent: {
+    project: {
+      id: string;
+      name: string;
+      url: string;
+    } | null;
+    document: {
+      id: string;
+      title: string;
+      project: {
+        id: string;
+        name: string;
+        url: string;
+      };
+    } | null;
+  };
+  user: {
+    id: string;
+    email: string;
+    name: string;
+    avatarUrl: string;
+  };
+  parent: {
+    id: string;
+    body: string;
+    createdAt: string;
+    user: {
+      id: string;
+      email: string;
+      name: string;
+      avatarUrl: string;
+    };
+  } | null;
+}
+
+interface CommentsResponse {
+  data: {
+    comments: {
+      nodes: Comment[];
+    };
+  };
+}
+
+/**
+ * Sets up a new webhook subscription for document comments in Linear.
+ * @see https://platform.zapier.com/build/cli-hook-trigger#1-write-the-subscribehook-function
+ * @see https://platform.zapier.com/build/cli-hook-trigger#subscribehook
+ */
+const subscribeHook = (z: ZObject, bundle: Bundle) => {
+  const data = {
+    url: bundle.targetUrl,
+    inputData:
+      bundle.inputData && Object.keys(bundle.inputData).length > 0
+        ? pick(bundle.inputData, ["creatorId", "projectId", "documentId"])
+        : undefined,
+  };
+
+  return z
+    .request({
+      url: "https://client-api.linear.app/connect/zapier/subscribe/commentDocument",
+      method: "POST",
+      body: data,
+    })
+    .then((response) => response.data);
+};
+
+/**
+ * Deletes a webhook subscription for document comments in Linear.
+ * @see https://platform.zapier.com/build/cli-hook-trigger#2-write-the-unsubscribehook-function
+ * @see https://platform.zapier.com/build/cli-hook-trigger#unsubscribehook
+ */
+const unsubscribeHook = (z: ZObject, bundle: Bundle) => {
+  // bundle.subscribeData contains the parsed response JSON from the subscribe request.
+  const hookId = bundle.subscribeData?.id;
+
+  return z
+    .request({
+      url: `https://client-api.linear.app/connect/zapier/unsubscribe/${hookId}`,
+      method: "DELETE",
+    })
+    .then((response) => response.data);
+};
+
+/**
+ * This processes inbound webhooks from Linear.
+ * @see https://platform.zapier.com/build/cli-hook-trigger#3-write-the-perform-function
+ * @see https://platform.zapier.com/build/cli-hook-trigger#perform
+ */
+const getComment = (z: ZObject, bundle: Bundle) => {
+  const comment = {
+    ...bundle.cleanedRequest.data,
+    querystring: undefined,
+  };
+
+  return [comment];
+};
+
+/**
+ * Fetches a list of comments from Linear to use as examples when building a Zap.
+ * @see https://platform.zapier.com/build/cli-hook-trigger#4-write-the-performlist-function
+ * @see https://platform.zapier.com/build/cli-hook-trigger#performlist
+ */
+const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
+  const variables = omitBy(
+    {
+      creatorId: bundle.inputData.creator_id,
+      projectId: bundle.inputData.project_id,
+      documentId: bundle.inputData.document_id,
+    },
+    (v: undefined) => v === undefined
+  );
+
+  const filters = [];
+  if ("creatorId" in variables) {
+    filters.push(`{ user: { id: { eq: $creatorId } } }`);
+  }
+  if ("projectId" in variables) {
+    filters.push(
+      `{ or: [{ documentContent: { project: { id: { eq: $projectId }} } }, { documentContent: { document: { project: { id: { eq: $projectId }}}}}] }`
+    );
+  }
+  if ("documentId" in variables) {
+    filters.push(`{ documentContent: { document: { id: { eq: $documentId }}}}`);
+  }
+
+  const response = await z.request({
+    url: "https://api.linear.app/graphql",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      authorization: bundle.authData.api_key,
+    },
+    body: {
+      query: `
+      query ZapierListCommentsV2${
+        Object.keys(variables).length === 0
+          ? ""
+          : `(
+        ${"creatorId" in variables ? "$creatorId: ID" : ""}
+        ${"projectId" in variables ? "$projectId: ID" : ""}
+        ${"documentId" in variables ? "$documentId: ID" : ""}
+      )`
+      } {
+        comments(
+          first: 25
+          ${
+            filters.length > 0
+              ? `
+          filter: {
+            and : [
+              ${filters.join("\n              ")}
+            ]
+          }`
+              : ""
+          }
+        ) {
+          nodes {
+            id
+            body
+            createdAt
+            resolvedAt
+            documentContent {
+              project {
+                id
+                name
+                url
+              }
+              document {
+                id
+                title
+                project {
+                  id
+                  name
+                  url
+                }
+              }
+            }
+            user {
+              id
+              email
+              name
+              avatarUrl
+            }
+            parent {
+              id
+              body
+              createdAt
+              user {
+                id
+                email
+                name
+                avatarUrl
+              }
+            }
+          }
+        }
+      }`,
+      variables: variables,
+    },
+    method: "POST",
+  });
+
+  const data = (response.json as CommentsResponse).data;
+  const comments = data.comments.nodes;
+
+  return comments.map((comment) => ({
+    ...comment,
+    id: `${comment.id}-${comment.createdAt}`,
+    commentId: comment.id,
+  }));
+};
+
+export const newDocumentCommentV2 = {
+  key: "newDocumentCommentV2",
+  noun: "Comment",
+  display: {
+    label: "New Document Comment V2",
+    description: "Triggers when a new document comment is created.",
+  },
+  operation: {
+    inputFields: [
+      {
+        required: false,
+        label: "Creator",
+        key: "creatorId",
+        helpText: "Only trigger on document comments added by this user.",
+        dynamic: "user.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Project ID",
+        key: "projectId",
+        helpText: "Only trigger on comments added to the documents or project description in the project with this ID.",
+      },
+      {
+        required: false,
+        label: "Document ID",
+        key: "documentId",
+        helpText: "Only trigger on comments added to the document with this ID.",
+      },
+    ],
+    type: "hook",
+    performSubscribe: subscribeHook,
+    performUnsubscribe: unsubscribeHook,
+    perform: getComment,
+    performList: getCommentList(),
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "body", label: "Body" },
+    ],
+    sample,
+  },
+};

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -249,9 +249,7 @@ export const newDocumentCommentV2 = {
     performUnsubscribe: unsubscribeHook,
     perform: getComment,
     performList: getCommentList(),
-    outputFields: () => {
-      return [];
-    },
+    outputFields: [],
     sample,
   },
 };

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -211,13 +211,7 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
   });
 
   const data = (response.json as CommentsResponse).data;
-  const comments = data.comments.nodes;
-
-  return comments.map((comment) => ({
-    ...comment,
-    id: `${comment.id}-${comment.createdAt}`,
-    commentId: comment.id,
-  }));
+  return data.comments.nodes;
 };
 
 export const newDocumentCommentV2 = {

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -1,6 +1,6 @@
 import { omitBy, pick } from "lodash";
 import { ZObject, Bundle } from "zapier-platform-core";
-import sample from "../samples/projectUpdateComment.json";
+import sample from "../samples/documentComment.json";
 
 interface Comment {
   id: string;


### PR DESCRIPTION
* Hides the old polling version of this trigger per [Zapier's recommended migration path](https://community.zapier.com/general-discussion-13/recommended-path-for-switching-existing-polling-trigger-to-rest-hooks-12463)
* Adds the new REST version of the trigger to the list of available triggers


* Setting up a zap with this new trigger:

https://github.com/user-attachments/assets/38ac3033-f092-41e0-885e-7d62b19e175a

* Zap in action:


https://github.com/user-attachments/assets/01ec1b22-6fb7-433d-a184-b10d53d2cb3d

