### PR TITLE
Add REST version of "New Issue Comment" trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/handleWebhook.ts
+++ b/src/handleWebhook.ts
@@ -1,0 +1,32 @@
+import { Bundle, ZObject } from "zapier-platform-core";
+
+/**
+ * This processes inbound webhooks from Linear.
+ * @see https://platform.zapier.com/build/cli-hook-trigger#3-write-the-perform-function
+ * @see https://platform.zapier.com/build/cli-hook-trigger#perform
+ */
+export const getWebhookData = (z: ZObject, bundle: Bundle) => {
+  const entity = {
+    ...bundle.cleanedRequest.data,
+    querystring: undefined,
+  };
+
+  return [entity];
+};
+
+/**
+ * Deletes a webhook subscription in Linear.
+ * @see https://platform.zapier.com/build/cli-hook-trigger#2-write-the-unsubscribehook-function
+ * @see https://platform.zapier.com/build/cli-hook-trigger#unsubscribehook
+ */
+export const unsubscribeHook = (z: ZObject, bundle: Bundle) => {
+  // bundle.subscribeData contains the parsed response JSON from the subscribe request.
+  const hookId = bundle.subscribeData?.id;
+
+  return z
+    .request({
+      url: `https://client-api.linear.app/connect/zapier/unsubscribe/${hookId}`,
+      method: "DELETE",
+    })
+    .then((response) => response.data);
+};

--- a/src/triggers/commentIssue.ts
+++ b/src/triggers/commentIssue.ts
@@ -56,12 +56,15 @@ interface CommentsResponse {
 const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
   const cursor = bundle.meta.page ? await z.cursor.get() : undefined;
 
-  const variables = omitBy({
-    creatorId: bundle.inputData.creator_id,
-    teamId: bundle.inputData.team_id,
-    issueId: bundle.inputData.issue,
-    after: cursor,
-  }, v => v === undefined);
+  const variables = omitBy(
+    {
+      creatorId: bundle.inputData.creator_id,
+      teamId: bundle.inputData.team_id,
+      issueId: bundle.inputData.issue,
+      after: cursor,
+    },
+    (v) => v === undefined
+  );
 
   const filters = [];
   if ("creatorId" in variables) {
@@ -92,12 +95,16 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
         comments(
           first: 25
           after: $after
-          ${filters.length > 0 ?`
+          ${
+            filters.length > 0
+              ? `
           filter: {
             and : [
               ${filters.join("\n              ")}
             ]
-          }` : ""}
+          }`
+              : ""
+          }
         ) {
           nodes {
             id
@@ -202,6 +209,7 @@ export const newIssueComment = {
   display: {
     label: "New Issue Comment",
     description: "Triggers when a new issue comment is created.",
+    hidden: true,
   },
   operation: {
     ...comment.operation,

--- a/src/triggers/commentIssueV2.ts
+++ b/src/triggers/commentIssueV2.ts
@@ -183,7 +183,7 @@ export const newIssueCommentInstant = {
         required: false,
         label: "Team",
         key: "teamId",
-        helpText: "Only trigger on issue comments created to this team.",
+        helpText: "Only trigger on issue comments created in this team.",
         dynamic: "team.id.name",
         altersDynamicFields: true,
       },

--- a/src/triggers/commentIssueV2.ts
+++ b/src/triggers/commentIssueV2.ts
@@ -47,8 +47,6 @@ interface CommentsResponse {
 }
 
 const subscribeHook = (z: ZObject, bundle: Bundle) => {
-  // bundle.targetUrl has the Hook URL this app should call when a recipe is created.
-  // https://platform.zapier.com/build/bundle#targeturl
   const data = {
     url: bundle.targetUrl,
     inputData:

--- a/src/triggers/commentIssueV2.ts
+++ b/src/triggers/commentIssueV2.ts
@@ -1,6 +1,6 @@
 import { omitBy, pick } from "lodash";
 import { ZObject, Bundle } from "zapier-platform-core";
-import sample from "../samples/documentComment.json";
+import sample from "../samples/issueComment.json";
 import { getWebhookData, unsubscribeHook } from "../handleWebhook";
 
 interface Comment {
@@ -9,21 +9,15 @@ interface Comment {
   url: string;
   createdAt: string;
   resolvedAt: string | null;
-  documentContent: {
-    project: {
+  issue: {
+    id: string;
+    identifier: string;
+    title: string;
+    url: string;
+    team: {
       id: string;
       name: string;
-      url: string;
-    } | null;
-    document: {
-      id: string;
-      title: string;
-      project: {
-        id: string;
-        name: string;
-        url: string;
-      };
-    } | null;
+    };
   };
   user: {
     id: string;
@@ -52,55 +46,45 @@ interface CommentsResponse {
   };
 }
 
-/**
- * Sets up a new webhook subscription for document comments in Linear.
- * @see https://platform.zapier.com/build/cli-hook-trigger#1-write-the-subscribehook-function
- * @see https://platform.zapier.com/build/cli-hook-trigger#subscribehook
- */
 const subscribeHook = (z: ZObject, bundle: Bundle) => {
+  // bundle.targetUrl has the Hook URL this app should call when a recipe is created.
+  // https://platform.zapier.com/build/bundle#targeturl
   const data = {
     url: bundle.targetUrl,
     inputData:
       bundle.inputData && Object.keys(bundle.inputData).length > 0
-        ? pick(bundle.inputData, ["creatorId", "projectId", "documentId"])
+        ? pick(bundle.inputData, ["creatorId", "teamId", "issueId"])
         : undefined,
   };
 
   return z
     .request({
-      url: "https://client-api.linear.app/connect/zapier/subscribe/commentDocument",
+      url: "https://client-api.linear.app/connect/zapier/subscribe/commentIssue",
       method: "POST",
       body: data,
     })
     .then((response) => response.data);
 };
 
-/**
- * Fetches a list of comments from Linear to use as examples when building a Zap.
- * @see https://platform.zapier.com/build/cli-hook-trigger#4-write-the-performlist-function
- * @see https://platform.zapier.com/build/cli-hook-trigger#performlist
- */
 const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
   const variables = omitBy(
     {
       creatorId: bundle.inputData.creatorId,
-      projectId: bundle.inputData.projectId,
-      documentId: bundle.inputData.documentId,
+      teamId: bundle.inputData.teamId,
+      issueId: bundle.inputData.issueId,
     },
-    (v: undefined) => v === undefined
+    (v) => v === undefined
   );
 
-  const filters = [` { and: [{ documentContent: { null: false } }] }`];
+  const filters = [`{ issue: { null: false } }`];
   if ("creatorId" in variables) {
     filters.push(`{ user: { id: { eq: $creatorId } } }`);
   }
-  if ("projectId" in variables) {
-    filters.push(
-      `{ or: [{ documentContent: { project: { id: { eq: $projectId }} } }, { documentContent: { document: { project: { id: { eq: $projectId }}}}}] }`
-    );
+  if ("teamId" in variables) {
+    filters.push(`{ issue: { team: { id: { eq: $teamId } } } }`);
   }
-  if ("documentId" in variables) {
-    filters.push(`{ documentContent: { document: { id: { eq: $documentId }}}}`);
+  if ("issueId" in variables) {
+    filters.push(`{ issue: { id: { eq: $issueId } } }`);
   }
 
   const response = await z.request({
@@ -117,8 +101,8 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
           ? ""
           : `(
         ${"creatorId" in variables ? "$creatorId: ID" : ""}
-        ${"projectId" in variables ? "$projectId: ID" : ""}
-        ${"documentId" in variables ? "$documentId: ID" : ""}
+        ${"teamId" in variables ? "$teamId: ID" : ""}
+        ${"issueId" in variables ? "$issueId: ID" : ""}
       )`
       } {
         comments(
@@ -139,20 +123,14 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
             body
             createdAt
             resolvedAt
-            documentContent {
-              project {
+            issue {
+              id
+              identifier
+              title
+              url
+              team {
                 id
                 name
-                url
-              }
-              document {
-                id
-                title
-                project {
-                  id
-                  name
-                  url
-                }
               }
             }
             user {
@@ -184,12 +162,12 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
   return data.comments.nodes;
 };
 
-export const newDocumentCommentInstant = {
-  key: "newDocumentCommentV2",
+export const newIssueCommentInstant = {
+  key: "newIssueCommentInstant",
   noun: "Comment",
   display: {
-    label: "New Document Comment",
-    description: "Triggers when a new document comment is created.",
+    label: "New Issue Comment",
+    description: "Triggers when a new issue comment is created.",
   },
   operation: {
     inputFields: [
@@ -203,15 +181,17 @@ export const newDocumentCommentInstant = {
       },
       {
         required: false,
-        label: "Project ID",
-        key: "projectId",
-        helpText: "Only trigger on comments added to the documents or project description in the project with this ID.",
+        label: "Team",
+        key: "teamId",
+        helpText: "Only trigger on issue comments created to this team.",
+        dynamic: "team.id.name",
+        altersDynamicFields: true,
       },
       {
         required: false,
-        label: "Document ID",
-        key: "documentId",
-        helpText: "Only trigger on comments added to the document with this ID.",
+        label: "Issue ID",
+        key: "issueId",
+        helpText: "Only trigger on comments added to this issue identified by its ID.",
       },
     ],
     type: "hook",

--- a/src/triggers/commentIssueV2.ts
+++ b/src/triggers/commentIssueV2.ts
@@ -175,7 +175,7 @@ export const newIssueCommentInstant = {
         required: false,
         label: "Creator",
         key: "creatorId",
-        helpText: "Only trigger on document comments added by this user.",
+        helpText: "Only trigger on issue comments added by this user.",
         dynamic: "user.id.name",
         altersDynamicFields: true,
       },


### PR DESCRIPTION
* Adds a `handleWebhook` file with a couple of common functions we can reuse across triggers
* Hides the polling version of the "new issue comment" trigger
* Adds a REST version of the trigger

### Creating the zap


https://github.com/user-attachments/assets/ac04bfac-23f9-4abd-bed7-169466e3dadc

### Zap in action


https://github.com/user-attachments/assets/e5ee6791-b277-4a2f-b2b9-9901831d833f

