### PR TITLE
Use `json-to-graphql-query` to work with GQL queries and arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@types/lodash": "4.14.202",
-    "json-to-graphql-query": "^2.3.0",
+    "json-to-graphql-query": "2.3.0",
     "lodash": "4.17.21",
     "zapier-platform-core": "15.5.3"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@types/lodash": "4.14.202",
+    "json-to-graphql-query": "^2.3.0",
     "lodash": "4.17.21",
     "zapier-platform-core": "15.5.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -1,7 +1,8 @@
-import { omitBy, pick } from "lodash";
+import { pick } from "lodash";
 import { ZObject, Bundle } from "zapier-platform-core";
 import sample from "../samples/documentComment.json";
 import { getWebhookData, unsubscribeHook } from "../handleWebhook";
+import { jsonToGraphQLQuery } from "json-to-graphql-query";
 
 interface Comment {
   id: string;
@@ -81,27 +82,72 @@ const subscribeHook = (z: ZObject, bundle: Bundle) => {
  * @see https://platform.zapier.com/build/cli-hook-trigger#performlist
  */
 const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
-  const variables = omitBy(
-    {
-      creatorId: bundle.inputData.creatorId,
-      projectId: bundle.inputData.projectId,
-      documentId: bundle.inputData.documentId,
-    },
-    (v: undefined) => v === undefined
-  );
+  const filters: unknown[] = [{ documentContent: { null: false } }];
+  if (bundle.inputData.creatorId) {
+    filters.push({ user: { id: { eq: bundle.inputData.creatorId } } });
+  }
+  if (bundle.inputData.projectId) {
+    filters.push({
+      or: [
+        { documentContent: { project: { id: { eq: bundle.inputData.projectId } } } },
+        { documentContent: { document: { project: { id: { eq: bundle.inputData.projectId } } } } },
+      ],
+    });
+  }
+  if (bundle.inputData.documentId) {
+    filters.push({ documentContent: { document: { id: { eq: bundle.inputData.documentId } } } });
+  }
+  const filter = { and: filters };
 
-  const filters = [` { and: [{ documentContent: { null: false } }] }`];
-  if ("creatorId" in variables) {
-    filters.push(`{ user: { id: { eq: $creatorId } } }`);
-  }
-  if ("projectId" in variables) {
-    filters.push(
-      `{ or: [{ documentContent: { project: { id: { eq: $projectId }} } }, { documentContent: { document: { project: { id: { eq: $projectId }}}}}] }`
-    );
-  }
-  if ("documentId" in variables) {
-    filters.push(`{ documentContent: { document: { id: { eq: $documentId }}}}`);
-  }
+  const jsonQuery = {
+    query: {
+      comments: {
+        __args: {
+          first: 25,
+          filter,
+        },
+        nodes: {
+          id: true,
+          body: true,
+          createdAt: true,
+          resolvedAt: true,
+          documentContent: {
+            project: {
+              id: true,
+              name: true,
+              url: true,
+            },
+            document: {
+              id: true,
+              title: true,
+              project: {
+                id: true,
+                name: true,
+                url: true,
+              },
+            },
+          },
+          user: {
+            id: true,
+            email: true,
+            name: true,
+            avatarUrl: true,
+          },
+          parent: {
+            id: true,
+            body: true,
+            createdAt: true,
+            user: {
+              id: true,
+              email: true,
+              name: true,
+              avatarUrl: true,
+            },
+          },
+        },
+      },
+    },
+  };
 
   const response = await z.request({
     url: "https://api.linear.app/graphql",
@@ -111,71 +157,7 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
       authorization: bundle.authData.api_key,
     },
     body: {
-      query: `
-      query ZapierListCommentsV2${
-        Object.keys(variables).length === 0
-          ? ""
-          : `(
-        ${"creatorId" in variables ? "$creatorId: ID" : ""}
-        ${"projectId" in variables ? "$projectId: ID" : ""}
-        ${"documentId" in variables ? "$documentId: ID" : ""}
-      )`
-      } {
-        comments(
-          first: 25
-          ${
-            filters.length > 0
-              ? `
-          filter: {
-            and : [
-              ${filters.join("\n              ")}
-            ]
-          }`
-              : ""
-          }
-        ) {
-          nodes {
-            id
-            body
-            createdAt
-            resolvedAt
-            documentContent {
-              project {
-                id
-                name
-                url
-              }
-              document {
-                id
-                title
-                project {
-                  id
-                  name
-                  url
-                }
-              }
-            }
-            user {
-              id
-              email
-              name
-              avatarUrl
-            }
-            parent {
-              id
-              body
-              createdAt
-              user {
-                id
-                email
-                name
-                avatarUrl
-              }
-            }
-          }
-        }
-      }`,
-      variables: variables,
+      query: jsonToGraphQLQuery(jsonQuery),
     },
     method: "POST",
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1785,6 +1785,11 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-to-graphql-query@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/json-to-graphql-query/-/json-to-graphql-query-2.3.0.tgz#cf2d4927f99c372c91abff699b2c3dd4cc2f825e"
+  integrity sha512-khZtaLLQ0HllFec+t89ZWduUZ0rmne/OpRm/39hyZUWDHNx9Yk4DgQzDtMeqd8zj2g5opBD4GHrdtH0JzKnN2g==
+
 json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"


### PR DESCRIPTION
This library makes it easy to work with real JSON structures when building the GQL query. Going forward, we can get rid of string concatenation when applying filters to fetch sample data while building zaps.