### PR TITLE
Add instant triggers for "new project update" and "updated project update"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/fetchFromLinear.ts
+++ b/src/fetchFromLinear.ts
@@ -1,0 +1,20 @@
+import { Bundle, ZObject } from "zapier-platform-core";
+
+/**
+ * Performs a query against the Linear GraphQL API and returns the response.
+ */
+export const fetchFromLinear = async (z: ZObject, bundle: Bundle, query: string, variables: Record<string, string>) => {
+  return await z.request({
+    url: "https://api.linear.app/graphql",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      authorization: bundle.authData.api_key,
+    },
+    body: {
+      query,
+      variables,
+    },
+    method: "POST",
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,25 +14,25 @@ import { projectMilestone } from "./triggers/projectMilestone";
 import { HttpResponse, ZObject } from "zapier-platform-core";
 import { createComment } from "./creates/createComment";
 import { estimate } from "./triggers/estimate";
-import { newDocumentCommentV2 } from "./triggers/commentDocumentV2";
+import { newDocumentCommentInstant } from "./triggers/commentDocumentV2";
 import { newIssueCommentInstant } from "./triggers/commentIssueV2";
 import { newProjectUpdateCommentInstant } from "./triggers/commentProjectUpdateV2";
 import { newProjectUpdateInstant, updatedProjectUpdateInstant } from "./triggers/projectUpdateV2";
 
 const handleErrors = (response: HttpResponse, z: ZObject) => {
-  if (response.request.url !== "https://linear-dev-zapier.ngrok.io/graphql") {
+  if (response.request.url !== "https://api.linear.app/graphql") {
     return response;
   }
 
   if (response.status === 200) {
     const data = response.json as any;
     const error = data.errors ? data.errors[0] : undefined;
+    z.console.log("handling errors", data);
     if (error && error.extensions.type === "authentication error") {
       throw new z.errors.ExpiredAuthError(`Authentication with Linear failed. Please reconnect.`);
     }
   } else {
     z.console.log("Catch error", response.status, response.json);
-    z.console.log("Error extensions", response.json.errors?.extensions);
     throw new z.errors.Error(`Something went wrong`, "request_execution_failed", 400);
   }
   return response;
@@ -54,7 +54,7 @@ const App = {
     [newProjectUpdateComment.key]: newProjectUpdateComment,
     [newProjectUpdateCommentInstant.key]: newProjectUpdateCommentInstant,
     [newDocumentComment.key]: newDocumentComment,
-    [newDocumentCommentV2.key]: newDocumentCommentV2,
+    [newDocumentCommentInstant.key]: newDocumentCommentInstant,
     [updatedProjectUpdate.key]: updatedProjectUpdate,
     [updatedProjectUpdateInstant.key]: updatedProjectUpdateInstant,
     [team.key]: team,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,24 +14,25 @@ import { projectMilestone } from "./triggers/projectMilestone";
 import { HttpResponse, ZObject } from "zapier-platform-core";
 import { createComment } from "./creates/createComment";
 import { estimate } from "./triggers/estimate";
-import { newDocumentCommentInstant } from "./triggers/commentDocumentV2";
+import { newDocumentCommentV2 } from "./triggers/commentDocumentV2";
 import { newIssueCommentInstant } from "./triggers/commentIssueV2";
 import { newProjectUpdateCommentInstant } from "./triggers/commentProjectUpdateV2";
+import { newProjectUpdateInstant, updatedProjectUpdateInstant } from "./triggers/projectUpdateV2";
 
 const handleErrors = (response: HttpResponse, z: ZObject) => {
-  if (response.request.url !== "https://api.linear.app/graphql") {
+  if (response.request.url !== "https://linear-dev-zapier.ngrok.io/graphql") {
     return response;
   }
 
   if (response.status === 200) {
     const data = response.json as any;
     const error = data.errors ? data.errors[0] : undefined;
-    z.console.log("handling errors", data);
     if (error && error.extensions.type === "authentication error") {
       throw new z.errors.ExpiredAuthError(`Authentication with Linear failed. Please reconnect.`);
     }
   } else {
     z.console.log("Catch error", response.status, response.json);
+    z.console.log("Error extensions", response.json.errors?.extensions);
     throw new z.errors.Error(`Something went wrong`, "request_execution_failed", 400);
   }
   return response;
@@ -49,11 +50,13 @@ const App = {
     [newIssueComment.key]: newIssueComment,
     [newIssueCommentInstant.key]: newIssueCommentInstant,
     [newProjectUpdate.key]: newProjectUpdate,
+    [newProjectUpdateInstant.key]: newProjectUpdateInstant,
     [newProjectUpdateComment.key]: newProjectUpdateComment,
     [newProjectUpdateCommentInstant.key]: newProjectUpdateCommentInstant,
     [newDocumentComment.key]: newDocumentComment,
-    [newDocumentCommentInstant.key]: newDocumentCommentInstant,
+    [newDocumentCommentV2.key]: newDocumentCommentV2,
     [updatedProjectUpdate.key]: updatedProjectUpdate,
+    [updatedProjectUpdateInstant.key]: updatedProjectUpdateInstant,
     [team.key]: team,
     [status.key]: status,
     [project.key]: project,

--- a/src/samples/projectUpdate.json
+++ b/src/samples/projectUpdate.json
@@ -1,9 +1,8 @@
 {
   "id": "4bec2b49-56bb-4a4f-a961-abf2148d4837",
   "body": "This is a project update body in Markdown format!",
-  "diffMarkdown": "This is a project update diff in Markdown format!",
-  "health": "onTrack|atRisk|offTrack",
-  "url": "https://linear.app/linear/updateA",
+  "health": "onTrack",
+  "url": "https://local.linear.dev/linear/updateA",
   "editedAt": "2022-10-27T21:20:59.199Z",
   "createdAt": "2022-10-27T21:20:59.199Z",
   "updatedAt": "2022-10-27T21:20:59.199Z",

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -3,6 +3,7 @@ import { ZObject, Bundle } from "zapier-platform-core";
 import sample from "../samples/documentComment.json";
 import { getWebhookData, unsubscribeHook } from "../handleWebhook";
 import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
+import { fetchFromLinear } from "../fetchFromLinear";
 
 interface Comment {
   id: string;
@@ -159,21 +160,7 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
   };
 
   const query = jsonToGraphQLQuery(jsonQuery);
-
-  const response = await z.request({
-    url: "https://api.linear.app/graphql",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      authorization: bundle.authData.api_key,
-    },
-    body: {
-      query,
-      variables,
-    },
-    method: "POST",
-  });
-
+  const response = await fetchFromLinear(z, bundle, query, variables);
   const data = (response.json as CommentsResponse).data;
   return data.comments.nodes;
 };

--- a/src/triggers/commentIssueV2.ts
+++ b/src/triggers/commentIssueV2.ts
@@ -3,6 +3,7 @@ import { ZObject, Bundle } from "zapier-platform-core";
 import sample from "../samples/issueComment.json";
 import { getWebhookData, unsubscribeHook } from "../handleWebhook";
 import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
+import { fetchFromLinear } from "../fetchFromLinear";
 
 interface Comment {
   id: string;
@@ -131,21 +132,7 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
     },
   };
   const query = jsonToGraphQLQuery(jsonQuery);
-
-  const response = await z.request({
-    url: "https://api.linear.app/graphql",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      authorization: bundle.authData.api_key,
-    },
-    body: {
-      query,
-      variables,
-    },
-    method: "POST",
-  });
-
+  const response = await fetchFromLinear(z, bundle, query, variables);
   const data = (response.json as CommentsResponse).data;
   return data.comments.nodes;
 };

--- a/src/triggers/commentProjectUpdateV2.ts
+++ b/src/triggers/commentProjectUpdateV2.ts
@@ -3,6 +3,7 @@ import { ZObject, Bundle } from "zapier-platform-core";
 import sample from "../samples/issueComment.json";
 import { getWebhookData, unsubscribeHook } from "../handleWebhook";
 import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
+import { fetchFromLinear } from "../fetchFromLinear";
 
 interface Comment {
   id: string;
@@ -138,21 +139,7 @@ const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
     },
   };
   const query = jsonToGraphQLQuery(jsonQuery);
-
-  const response = await z.request({
-    url: "https://api.linear.app/graphql",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      authorization: bundle.authData.api_key,
-    },
-    body: {
-      query,
-      variables,
-    },
-    method: "POST",
-  });
-
+  const response = await fetchFromLinear(z, bundle, query, variables);
   const data = (response.json as CommentsResponse).data;
   return data.comments.nodes;
 };

--- a/src/triggers/projectUpdate.ts
+++ b/src/triggers/projectUpdate.ts
@@ -151,6 +151,7 @@ export const newProjectUpdate = {
   display: {
     label: "New Project Update",
     description: "Triggers when a new project update is created.",
+    hidden: true,
   },
   operation: {
     ...projectUpdate.operation,
@@ -165,6 +166,7 @@ export const updatedProjectUpdate = {
   display: {
     label: "Updated Project Update",
     description: "Triggers when a project update is updated.",
+    hidden: true,
   },
   operation: {
     ...projectUpdate.operation,

--- a/src/triggers/projectUpdateV2.ts
+++ b/src/triggers/projectUpdateV2.ts
@@ -1,0 +1,182 @@
+import { pick } from "lodash";
+import { ZObject, Bundle } from "zapier-platform-core";
+import sample from "../samples/issueComment.json";
+import { getWebhookData, unsubscribeHook } from "../handleWebhook";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
+
+interface ProjectUpdate {
+  id: string;
+  body: string;
+  url: string;
+  createdAt: Date;
+  updatedAt: Date;
+  editedAt: Date | null;
+  health: string;
+  project: {
+    id: string;
+    name: string;
+  };
+  user: {
+    id: string;
+    name: string;
+    email: string;
+  };
+}
+
+interface ProjectUpdatesResponse {
+  data: {
+    projectUpdates: {
+      nodes: ProjectUpdate[];
+    };
+  };
+}
+
+type EventType = "create" | "update";
+
+const subscribeHook = (eventType: EventType) => async (z: ZObject, bundle: Bundle) => {
+  z.console.log("bundle", bundle);
+  const data = {
+    url: bundle.targetUrl,
+    inputData:
+      bundle.inputData && Object.keys(bundle.inputData).length > 0
+        ? pick(bundle.inputData, ["creatorId", "projectId", "teamId"])
+        : undefined,
+  };
+
+  const webhookType = eventType === "create" ? "createProjectUpdate" : "updateProjectUpdate";
+  return z
+    .request({
+      url: `https://client-api.linear.app/connect/zapier/subscribe/${webhookType}`,
+      method: "POST",
+      body: data,
+    })
+    .then((response) => response.data);
+};
+
+const getProjectUpdateList = () => async (z: ZObject, bundle: Bundle) => {
+  const variables: Record<string, string> = {};
+  const variableSchema: Record<string, string> = {};
+  const filters: unknown[] = [];
+  if (bundle.inputData.creatorId) {
+    variableSchema.creatorId = "ID";
+    variables.creatorId = bundle.inputData.creatorId;
+    filters.push({ user: { id: { eq: new VariableType("creatorId") } } });
+  }
+  if (bundle.inputData.teamId) {
+    variableSchema.teamId = "ID";
+    variables.teamId = bundle.inputData.teamId;
+    filters.push({ project: { accessibleTeams: { id: { eq: new VariableType("teamId") } } } });
+  }
+  if (bundle.inputData.projectId) {
+    variableSchema.projectId = "ID";
+    variables.projectId = bundle.inputData.projectId;
+    filters.push({ project: { id: { eq: new VariableType("projectId") } } });
+  }
+  const filter = { and: filters };
+
+  const jsonQuery = {
+    query: {
+      __variables: variableSchema,
+      projectUpdates: {
+        __args: {
+          first: 25,
+          filter,
+        },
+        nodes: {
+          id: true,
+          body: true,
+          url: true,
+          createdAt: true,
+          updatedAt: true,
+          editedAt: true,
+          health: true,
+          project: {
+            id: true,
+            name: true,
+          },
+          user: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+    },
+  };
+  const query = jsonToGraphQLQuery(jsonQuery);
+
+  const response = await z.request({
+    url: "https://api.linear.app/graphql",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      authorization: bundle.authData.api_key,
+    },
+    body: {
+      query,
+      variables,
+    },
+    method: "POST",
+  });
+
+  const data = (response.json as ProjectUpdatesResponse).data;
+  return data.projectUpdates.nodes;
+};
+
+const operationBase = {
+  inputFields: [
+    {
+      required: false,
+      label: "Creator",
+      key: "creatorId",
+      helpText: "Only trigger on project updates added by this user.",
+      dynamic: "user.id.name",
+      altersDynamicFields: true,
+    },
+    {
+      required: false,
+      label: "Project ID",
+      key: "projectId",
+      helpText: "Only trigger on project updates tied to this project.",
+    },
+    {
+      required: false,
+      label: "Team",
+      key: "teamId",
+      helpText: "Only trigger on project updates created in projects tied to this team.",
+      dynamic: "team.id.name",
+      altersDynamicFields: true,
+    },
+  ],
+  type: "hook",
+  perform: getWebhookData,
+  performUnsubscribe: unsubscribeHook,
+  performList: getProjectUpdateList(),
+  sample,
+};
+
+export const newProjectUpdateInstant = {
+  noun: "Project Update",
+  key: "newProjectUpdateInstant",
+  display: {
+    label: "New Project Update",
+    description: "Triggers when a new project update is created.",
+  },
+  operation: {
+    ...operationBase,
+    performSubscribe: subscribeHook("create"),
+  },
+};
+
+export const updatedProjectUpdateInstant = {
+  noun: "Project Update",
+  key: "updatedProjectUpdateInstant",
+  display: {
+    label: "Updated Project Update",
+    description: "Triggers when a project update is updated.",
+  },
+  operation: {
+    ...operationBase,
+    performSubscribe: subscribeHook("update"),
+  },
+};

--- a/src/triggers/projectUpdateV2.ts
+++ b/src/triggers/projectUpdateV2.ts
@@ -3,6 +3,7 @@ import { ZObject, Bundle } from "zapier-platform-core";
 import sample from "../samples/issueComment.json";
 import { getWebhookData, unsubscribeHook } from "../handleWebhook";
 import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
+import { fetchFromLinear } from "../fetchFromLinear";
 
 interface ProjectUpdate {
   id: string;
@@ -34,7 +35,6 @@ interface ProjectUpdatesResponse {
 type EventType = "create" | "update";
 
 const subscribeHook = (eventType: EventType) => async (z: ZObject, bundle: Bundle) => {
-  z.console.log("bundle", bundle);
   const data = {
     url: bundle.targetUrl,
     inputData:
@@ -104,21 +104,7 @@ const getProjectUpdateList = () => async (z: ZObject, bundle: Bundle) => {
     },
   };
   const query = jsonToGraphQLQuery(jsonQuery);
-
-  const response = await z.request({
-    url: "https://api.linear.app/graphql",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      authorization: bundle.authData.api_key,
-    },
-    body: {
-      query,
-      variables,
-    },
-    method: "POST",
-  });
-
+  const response = await fetchFromLinear(z, bundle, query, variables);
   const data = (response.json as ProjectUpdatesResponse).data;
   return data.projectUpdates.nodes;
 };


### PR DESCRIPTION
Two very similar triggers; thankfully we get to reuse the bulk of the code across both.

Closes USP-6740, USP-6745