### PR TITLE
Turn the project input into a dynamic list for comment and project update triggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { newDocumentCommentInstant } from "./triggers/commentDocumentV2";
 import { newIssueCommentInstant } from "./triggers/commentIssueV2";
 import { newProjectUpdateCommentInstant } from "./triggers/commentProjectUpdateV2";
 import { newProjectUpdateInstant, updatedProjectUpdateInstant } from "./triggers/projectUpdateV2";
+import { projectWithoutTeam } from "./triggers/projectWithoutTeam";
 
 const handleErrors = (response: HttpResponse, z: ZObject) => {
   if (response.request.url !== "https://api.linear.app/graphql") {
@@ -60,6 +61,7 @@ const App = {
     [team.key]: team,
     [status.key]: status,
     [project.key]: project,
+    [projectWithoutTeam.key]: projectWithoutTeam,
     [projectMilestone.key]: projectMilestone,
     [label.key]: label,
     [user.key]: user,

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -184,9 +184,11 @@ export const newDocumentCommentInstant = {
       },
       {
         required: false,
-        label: "Project ID",
+        label: "Project",
         key: "projectId",
-        helpText: "Only trigger on comments added to the documents or project description in the project with this ID.",
+        helpText: "Only trigger on document comments tied to this project.",
+        dynamic: "projectWithoutTeam.id.name",
+        altersDynamicFields: true,
       },
       {
         required: false,

--- a/src/triggers/commentProjectUpdateV2.ts
+++ b/src/triggers/commentProjectUpdateV2.ts
@@ -163,9 +163,11 @@ export const newProjectUpdateCommentInstant = {
       },
       {
         required: false,
-        label: "Project ID",
+        label: "Project",
         key: "projectId",
-        helpText: "Only trigger on project update comments added to this project identified by its ID",
+        helpText: "Only trigger on project update comments tied to this project.",
+        dynamic: "projectWithoutTeam.id.name",
+        altersDynamicFields: true,
       },
     ],
     type: "hook",

--- a/src/triggers/projectUpdateV2.ts
+++ b/src/triggers/projectUpdateV2.ts
@@ -121,9 +121,11 @@ const operationBase = {
     },
     {
       required: false,
-      label: "Project ID",
+      label: "Project",
       key: "projectId",
       helpText: "Only trigger on project updates tied to this project.",
+      dynamic: "projectWithoutTeam.id.name",
+      altersDynamicFields: true,
     },
     {
       required: false,

--- a/src/triggers/projectWithoutTeam.ts
+++ b/src/triggers/projectWithoutTeam.ts
@@ -1,0 +1,63 @@
+import { ZObject, Bundle } from "zapier-platform-core";
+import { fetchFromLinear } from "../fetchFromLinear";
+
+interface ProjectsResponse {
+  data: {
+    projects: {
+      nodes: {
+        id: string;
+        name: string;
+      }[];
+      pageInfo: {
+        hasNextPage: boolean;
+        endCursor: string;
+      };
+    };
+  };
+}
+
+const getProjectList = async (z: ZObject, bundle: Bundle) => {
+  const cursor = bundle.meta.page ? await z.cursor.get() : undefined;
+  const query = `
+      query ZapierListProjects($after: String) {
+        projects(
+          first: 100
+          after: $after
+          orderBy: updatedAt
+        ) {
+          nodes {
+            id
+            name
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }`;
+  const response = await fetchFromLinear(z, bundle, query, cursor ? { after: cursor } : {});
+  const data = (response.json as ProjectsResponse).data;
+  const projects = data.projects.nodes;
+
+  // Set cursor for pagination
+  if (data.projects.pageInfo.hasNextPage) {
+    await z.cursor.set(data.projects.pageInfo.endCursor);
+  }
+
+  return projects;
+};
+
+export const projectWithoutTeam = {
+  key: "projectWithoutTeam",
+  noun: "Project",
+  display: {
+    label: "Get project",
+    hidden: true,
+    description:
+      "The only purpose of this trigger is to populate the dropdown list of projects in the UI, thus, it's hidden.",
+  },
+  operation: {
+    perform: getProjectList,
+    canPaginate: true,
+  },
+};


### PR DESCRIPTION
We have a version of this that requires a team ID for the issue triggers. For these other triggers, we can use a broader query sorted by `updatedAt` to populate the dynamic input.

![CleanShot 2024-10-01 at 15 41 20](https://github.com/user-attachments/assets/5aa171c9-1fe3-4d1a-ad6b-f9066caecc89)
