### PR TITLE
Add "create issue attachment" action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/creates/createIssue.ts
+++ b/src/creates/createIssue.ts
@@ -24,9 +24,9 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
   const priority = bundle.inputData.priority ? parseInt(bundle.inputData.priority) : 0;
   const estimate = bundle.inputData.estimate ? parseInt(bundle.inputData.estimate) : null;
 
-  const subscriberIds: string[] = []
+  const subscriberIds: string[] = [];
   if (bundle.inputData.subscriber_emails) {
-    z.console.log(`Getting subscribers by emails: ${bundle.inputData.subscriber_emails.length}`)
+    z.console.log(`Getting subscribers by emails: ${bundle.inputData.subscriber_emails.length}`);
     const usersQuery = `
       query ZapierUsersByEmails($filter: UserFilter, $first: Int) {
         users(filter: $filter, first: $first) {
@@ -38,10 +38,10 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
     `;
     const usersVariables = {
       filter: {
-        email: {in: bundle.inputData.subscriber_emails}
+        email: { in: bundle.inputData.subscriber_emails },
       },
-      first: 100
-    }
+      first: 100,
+    };
     // Transform subscriber emails to user ids
     const usersResponse = await z.request({
       url: "https://api.linear.app/graphql",
@@ -72,7 +72,7 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
 
     if (users.errors && users.errors.length) {
       const error = users.errors[0];
-      z.console.error(`Failed to get subscribers: ${JSON.stringify(error)}`)
+      z.console.error(`Failed to get subscribers: ${JSON.stringify(error)}`);
       throw new z.errors.Error(
         (error.extensions && error.extensions.userPresentableMessage) || error.message,
         "invalid_input",
@@ -80,8 +80,8 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
       );
     }
 
-    z.console.log(`Got ${users.data?.users.nodes.length} subscribers`)
-    subscriberIds.push(...(users.data?.users.nodes.map(user => user.id) || []))
+    z.console.log(`Got ${users.data?.users.nodes.length} subscribers`);
+    subscriberIds.push(...(users.data?.users.nodes.map((user) => user.id) || []));
   }
 
   const variables = {
@@ -97,7 +97,7 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
     projectMilestoneId: bundle.inputData.project_milestone_id,
     dueDate: bundle.inputData.due_date,
     labelIds: bundle.inputData.labels || [],
-    subscriberIds
+    subscriberIds,
   };
 
   const query = `
@@ -280,7 +280,7 @@ export const createIssue = {
     ],
     sample: {
       data: {
-        id: "4",
+        id: "7b647c45-c528-464d-8634-eecea0f73033",
         title: "Do the roar",
         url: "https://linear.app/team-best-team/issue/ENG-118/do-the-roar",
         identifier: "ENG-118",

--- a/src/creates/createIssueAttachment.ts
+++ b/src/creates/createIssueAttachment.ts
@@ -1,0 +1,100 @@
+import { Bundle, ZObject } from "zapier-platform-core";
+import { fetchFromLinear } from "../fetchFromLinear";
+
+interface AttachmentCreateResponse {
+  data?: { attachmentCreate: { attachment: { id: string; url: string; title: string }; success: boolean } };
+  errors?: {
+    message: string;
+    extensions?: {
+      userPresentableMessage?: string;
+    };
+  }[];
+}
+
+const createAttachmentRequest = async (z: ZObject, bundle: Bundle) => {
+  const variables = {
+    issueId: bundle.inputData.issue,
+    url: bundle.inputData.url,
+    title: bundle.inputData.title || "",
+  };
+
+  const query = `
+      mutation ZapierAttachmentCreate(
+        $issueId: String!,
+        $url: String!,
+        $title: String!
+      ) {
+        attachmentCreate(input: {
+          issueId: $issueId,
+          url: $url,
+          title: $title
+        }) {
+          attachment {
+            id
+            url
+            title
+          }
+          success
+        }
+      }`;
+
+  const response = await fetchFromLinear(z, bundle, query, variables);
+  const data = response.json as AttachmentCreateResponse;
+
+  if (data.errors && data.errors.length) {
+    const error = data.errors[0];
+    throw new z.errors.Error(
+      (error.extensions && error.extensions.userPresentableMessage) || error.message,
+      "invalid_input",
+      400
+    );
+  }
+
+  if (data.data && data.data.attachmentCreate && data.data.attachmentCreate.success) {
+    return data.data.attachmentCreate.attachment;
+  } else {
+    const error = data.errors ? data.errors[0].message : "Something went wrong";
+    throw new z.errors.Error("Failed to create an attachment", error, 400);
+  }
+};
+
+export const createIssueAttachment = {
+  key: "createIssueAttachment",
+  display: {
+    hidden: false,
+    description: "Create a new issue URL attachment in Linear",
+    label: "Create Issue Attachment",
+  },
+  noun: "Attachment",
+  operation: {
+    perform: createAttachmentRequest,
+    inputFields: [
+      {
+        required: true,
+        label: "Issue",
+        helpText: "The ID of the issue. Both UUID and issue identifier formats are accepted.",
+        key: "issue",
+      },
+      {
+        required: true,
+        label: "URL",
+        helpText: "The URL of this attachment.",
+        key: "url",
+      },
+      {
+        required: false,
+        label: "Title",
+        helpText: "The title of this attachment.",
+        key: "title",
+      },
+    ],
+    sample: {
+      data: {
+        attachmentCreate: {
+          attachment: { id: "a25cce1b-510d-433f-af50-1373efc05a4a", url: "https://www.example.com", title: "My title" },
+          success: true,
+        },
+      },
+    },
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { newIssueInstant, updatedIssueInstant } from "./triggers/issueV2";
 import { initiative } from "./triggers/initiative";
 import { projectStatus } from "./triggers/projectStatus";
 import { newProjectInstant } from "./triggers/newProject";
+import { createIssueAttachment } from "./creates/createIssueAttachment";
 
 const handleErrors = (response: HttpResponse, z: ZObject) => {
   if (response.request.url !== "https://api.linear.app/graphql") {
@@ -48,6 +49,7 @@ const App = {
   creates: {
     [createIssue.key]: createIssue,
     [createComment.key]: createComment,
+    [createIssueAttachment.key]: createIssueAttachment,
   },
   triggers: {
     [newIssue.key]: newIssue,


### PR DESCRIPTION
* Adds a new "create issue attachment" action that takes in an issue ID, URL, and optional attachment title
* The original feature request was to add a URL field to the "create issue" action, but this is more versatile because it also lets you add a link to an existing issue without tying it to issue creation. You can add an attachment to a newly created issue and reference variables from previous steps for any of the inputs like this:


![CleanShot 2024-10-08 at 14 29 01](https://github.com/user-attachments/assets/860c9bd0-8a48-4147-b817-03e1df4bfeb7)
