### PR TITLE
Include labels in sample data in issue triggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/triggers/issueV2.ts
+++ b/src/triggers/issueV2.ts
@@ -225,6 +225,16 @@ const getIssueList =
                 url: true,
                 title: true,
               },
+              labels: {
+                nodes: {
+                  id: true,
+                  color: true,
+                  name: true,
+                  parent: {
+                    id: true,
+                  },
+                },
+              },
             },
           },
         },


### PR DESCRIPTION
Diff is best viewed without whitespace.

Label data is exposed in issue webhooks, so the new triggers do already expose them. However, the sample data we fetch from the API when a user is creating a new zap doesn't expose them yet, so users don't have a good way to know that they can actually access these fields. This PR begins fetching labels from the API when querying it for sample data.

![CleanShot 2024-10-14 at 22 02 59@2x](https://github.com/user-attachments/assets/43a946c8-26bc-4fc2-8496-bb454b8474bc)
