### PR TITLE
Support template ID as an issue creation input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/creates/createIssue.ts
+++ b/src/creates/createIssue.ts
@@ -22,8 +22,8 @@ interface CreateIssueRequestResponse {
 }
 
 const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
-  const priority = bundle.inputData.priority ? parseInt(bundle.inputData.priority) : 0;
-  const estimate = bundle.inputData.estimate ? parseInt(bundle.inputData.estimate) : null;
+  const priority = bundle.inputData.priority ? parseInt(bundle.inputData.priority) : undefined;
+  const estimate = bundle.inputData.estimate ? parseInt(bundle.inputData.estimate) : undefined;
 
   const subscriberIds: string[] = [];
   if (bundle.inputData.subscriber_emails) {
@@ -98,8 +98,8 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
     projectId: bundle.inputData.project_id,
     projectMilestoneId: bundle.inputData.project_milestone_id,
     dueDate: bundle.inputData.due_date,
-    labelIds: bundle.inputData.labels || [],
-    subscriberIds,
+    labelIds: bundle.inputData.labels || undefined,
+    subscriberIds: subscriberIds.length > 0 ? subscriberIds : undefined,
   };
 
   const query = `

--- a/src/creates/createIssue.ts
+++ b/src/creates/createIssue.ts
@@ -1,4 +1,5 @@
 import { Bundle, ZObject } from "zapier-platform-core";
+import { fetchFromLinear } from "../fetchFromLinear";
 
 interface CreateIssueRequestResponse {
   data?: {
@@ -86,6 +87,7 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
 
   const variables = {
     teamId: bundle.inputData.team_id,
+    templateId: bundle.inputData.templateId,
     title: bundle.inputData.title,
     description: bundle.inputData.description,
     priority: priority,
@@ -103,6 +105,7 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
   const query = `
       mutation ZapierIssueCreate(
         $teamId: String!,
+        $templateId: String,
         $title: String!,
         $description: String,
         $priority: Int,
@@ -118,6 +121,7 @@ const createIssueRequest = async (z: ZObject, bundle: Bundle) => {
       ) {
         issueCreate(input: {
           teamId: $teamId,
+          templateId: $templateId,
           title: $title,
           description: $description,
           priority: $priority,
@@ -190,6 +194,15 @@ export const createIssue = {
 
     inputFields: [
       {
+        label: "Template",
+        helpText:
+          "The template to use for the issue. If no team has been selected yet, only workspace templates will be available. If other inputs are provided, they will override the template values.",
+        key: "templateId",
+        dynamic: "issueTemplates.id.name",
+        altersDynamicFields: true,
+      },
+      // Even if a template is chosen, we can't set a dynamic field programmatically based on another input: https://github.com/zapier/zapier-platform-cli#customdynamic-fields
+      {
         required: true,
         label: "Team",
         key: "team_id",
@@ -197,11 +210,30 @@ export const createIssue = {
         dynamic: "team.id.name",
         altersDynamicFields: true,
       },
-      {
-        required: true,
-        label: "Title",
-        helpText: "The title of the issue",
-        key: "title",
+      // Populate title with the template's title if applicable
+      async function (z: ZObject, bundle: Bundle) {
+        const baseTitle = {
+          label: "Title",
+          helpText: "The title of the issue",
+          key: "title",
+          required: true,
+        };
+        if (bundle.inputData.templateId) {
+          const query = `
+            query ZapierTemplate($templateId: String!) {
+              template(id: $templateId) {
+                templateData
+              }
+            }`;
+          const response = await fetchFromLinear(z, bundle, query, { templateId: bundle.inputData.templateId });
+
+          const template = response.json.data.template;
+          const templateData = JSON.parse(template.templateData);
+          if (templateData.title) {
+            return { ...baseTitle, default: templateData.title };
+          }
+        }
+        return baseTitle;
       },
       {
         label: "Description",

--- a/src/creates/createIssue.ts
+++ b/src/creates/createIssue.ts
@@ -230,7 +230,7 @@ export const createIssue = {
           const template = response.json.data.template;
           const templateData = JSON.parse(template.templateData);
           if (templateData.title) {
-            return { ...baseTitle, default: templateData.title };
+            return { ...baseTitle, required: false };
           }
         }
         return baseTitle;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { newProjectInstant } from "./triggers/newProject";
 import { createIssueAttachment } from "./creates/createIssueAttachment";
 import { createProject } from "./creates/createProject";
 import { updateIssue } from "./creates/updateIssue";
+import { issueTemplates } from "./triggers/issueTemplates";
 
 const handleErrors = (response: HttpResponse, z: ZObject) => {
   if (response.request.url !== "https://api.linear.app/graphql") {
@@ -71,6 +72,7 @@ const App = {
     [updatedProjectUpdate.key]: updatedProjectUpdate,
     [updatedProjectUpdateInstant.key]: updatedProjectUpdateInstant,
     [team.key]: team,
+    [issueTemplates.key]: issueTemplates,
     [status.key]: status,
     [project.key]: project,
     [projectWithoutTeam.key]: projectWithoutTeam,

--- a/src/triggers/issueTemplates.ts
+++ b/src/triggers/issueTemplates.ts
@@ -1,0 +1,86 @@
+import { ZObject, Bundle } from "zapier-platform-core";
+import { fetchFromLinear } from "../fetchFromLinear";
+import { omitBy } from "lodash";
+
+interface TemplateResponse {
+  id: string;
+  name: string;
+}
+
+interface TemplatesResponseTeam {
+  data: {
+    team: {
+      templates: {
+        nodes: TemplateResponse[];
+      };
+    };
+  };
+}
+
+interface TemplatesResponseWorkspace {
+  data: {
+    organization: {
+      templates: {
+        nodes: TemplateResponse[];
+      };
+    };
+  };
+}
+
+const getTemplateList = async (z: ZObject, bundle: Bundle) => {
+  const teamId = bundle.inputData.teamId || bundle.inputData.team_id;
+  const cursor = bundle.meta.page ? await z.cursor.get() : undefined;
+  // We fetch team and workspace templates if a team ID has been specified already, and only workspace templates if not
+  const query = teamId
+    ? `
+    query ZapierListTemplates($teamId: String!, $after: String) {
+      team(id: $teamId) {
+        templates(first: 50, after: $after, filter: { type: { eq: "issue" } }) {
+          nodes {
+            id
+            name
+          }
+        }
+      }
+    }`
+    : `
+    query ZapierListTemplates($after: String) {
+      organization {
+        templates(first: 50, after: $after, filter: { type: { eq: "issue" } }) {
+          nodes {
+            id
+            name
+          }
+        }
+      }
+    }`;
+  const variables = omitBy({ teamId, after: cursor }, (v) => v === undefined);
+
+  const response = await fetchFromLinear(z, bundle, query, variables);
+  const data = (response.json as TemplatesResponseTeam | TemplatesResponseWorkspace).data;
+  const templates = "team" in data ? data.team.templates.nodes : data.organization.templates.nodes;
+
+  const nextCursor = templates?.[templates.length - 1]?.id;
+  if (nextCursor) {
+    await z.cursor.set(nextCursor);
+  }
+
+  return templates;
+};
+
+export const issueTemplates = {
+  key: "issueTemplates",
+  noun: "Issue Templates",
+
+  display: {
+    label: "Get issue templates",
+    hidden: true,
+    description:
+      "The only purpose of this trigger is to populate the dropdown list of issue templates in the UI, thus, it's hidden.",
+  },
+
+  operation: {
+    perform: getTemplateList,
+    canPaginate: true,
+  },
+};


### PR DESCRIPTION
Now that our API supports `templateId` as an input during issue creation, this is relatively straightforward. I pull the title from the template if it has one, but you have to select team yourself since Zapier doesn't let me use a function to set the value of a dynamic dropdown.