### PR TITLE
Don't set priority to 0 if unspecified in `updateIssue`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/creates/updateIssue.ts
+++ b/src/creates/updateIssue.ts
@@ -30,7 +30,7 @@ const updateIssueRequest = async (z: ZObject, bundle: Bundle) => {
   if (!bundle.inputData.issueIdToUpdate) {
     throw new z.errors.HaltedError("You must specify the ID of the issue to update");
   }
-  const priority = bundle.inputData.priority ? parseInt(bundle.inputData.priority) : 0;
+  const priority = bundle.inputData.priority ? parseInt(bundle.inputData.priority) : undefined;
   const estimate = bundle.inputData.estimate ? parseInt(bundle.inputData.estimate) : undefined;
   let labelIds: string[] | undefined = undefined;
   if (bundle.inputData.labels && bundle.inputData.labels.length > 0) {


### PR DESCRIPTION
We should maintain the issue's existing priority instead of overwriting to "no priority"