### PR TITLE
fix: Needs a title case label publishing error

### DIFF
--- a/src/creates/addIssueLabel.ts
+++ b/src/creates/addIssueLabel.ts
@@ -83,7 +83,7 @@ export const addIssueLabel = {
   display: {
     hidden: false,
     description: "Add a label to an existing issue in Linear",
-    label: "Add Label To Issue",
+    label: "Add Label to Issue",
   },
 
   noun: "Label",


### PR DESCRIPTION
Either Zapier tightened their publishing rules or you never committed this change

<img width="455" alt="image" src="https://github.com/user-attachments/assets/96f15046-c2e2-4e83-b49d-cac24180038d" />
