### PR TITLE
Revert "Remove old polling triggers"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "4.8.4",
+  "version": "4.8.3",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "4.8.3",
+  "version": "4.8.5",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,25 @@
 import { addBearerHeader, authentication } from "./authentication";
 import { createIssue } from "./creates/createIssue";
+import { newIssueComment } from "./triggers/commentIssue";
+import { newProjectUpdateComment } from "./triggers/commentProjectUpdate";
+import { newDocumentComment } from "./triggers/commentDocument";
+import { newIssue, updatedIssue } from "./triggers/issue";
 import { team } from "./triggers/team";
 import { status } from "./triggers/status";
 import { label } from "./triggers/label";
 import { user } from "./triggers/user";
 import { project } from "./triggers/project";
+import { newProjectUpdate, updatedProjectUpdate } from "./triggers/projectUpdate";
 import { projectMilestone } from "./triggers/projectMilestone";
 import { HttpResponse, ZObject } from "zapier-platform-core";
 import { createComment } from "./creates/createComment";
 import { estimate } from "./triggers/estimate";
-import { newDocumentCommentInstant } from "./triggers/commentDocument";
-import { newIssueCommentInstant } from "./triggers/commentIssue";
-import { newProjectUpdateCommentInstant } from "./triggers/commentProjectUpdate";
+import { newDocumentCommentInstant } from "./triggers/commentDocumentV2";
+import { newIssueCommentInstant } from "./triggers/commentIssueV2";
+import { newProjectUpdateCommentInstant } from "./triggers/commentProjectUpdateV2";
 import { newProjectUpdateInstant, updatedProjectUpdateInstant } from "./triggers/projectUpdateV2";
 import { projectWithoutTeam } from "./triggers/projectWithoutTeam";
-import { newIssueInstant, updatedIssueInstant } from "./triggers/issue";
+import { newIssueInstant, updatedIssueInstant } from "./triggers/issueV2";
 import { initiative } from "./triggers/initiative";
 import { projectStatus } from "./triggers/projectStatus";
 import { newProjectInstant, updatedProjectInstant } from "./triggers/newProject";
@@ -66,12 +71,19 @@ const App = {
     [createCustomerNeed.key]: createCustomerNeed,
   },
   triggers: {
+    [newIssue.key]: newIssue,
     [newIssueInstant.key]: newIssueInstant,
+    [updatedIssue.key]: updatedIssue,
     [updatedIssueInstant.key]: updatedIssueInstant,
+    [newIssueComment.key]: newIssueComment,
     [newIssueCommentInstant.key]: newIssueCommentInstant,
+    [newProjectUpdate.key]: newProjectUpdate,
     [newProjectUpdateInstant.key]: newProjectUpdateInstant,
+    [newProjectUpdateComment.key]: newProjectUpdateComment,
     [newProjectUpdateCommentInstant.key]: newProjectUpdateCommentInstant,
+    [newDocumentComment.key]: newDocumentComment,
     [newDocumentCommentInstant.key]: newDocumentCommentInstant,
+    [updatedProjectUpdate.key]: updatedProjectUpdate,
     [updatedProjectUpdateInstant.key]: updatedProjectUpdateInstant,
     [newInitiativeUpdateInstant.key]: newInitiativeUpdateInstant,
     [updatedInitiativeUpdateInstant.key]: updatedInitiativeUpdateInstant,

--- a/src/searches/issue.ts
+++ b/src/searches/issue.ts
@@ -1,5 +1,5 @@
 import { ZObject, Bundle } from "zapier-platform-core";
-import { IssueCommon } from "../triggers/issue";
+import { IssueCommon } from "../triggers/issueV2";
 import sample from "../samples/issue.json";
 
 interface IssueResponse {

--- a/src/triggers/commentDocument.ts
+++ b/src/triggers/commentDocument.ts
@@ -1,207 +1,235 @@
-import { pick } from "lodash";
+import { omitBy } from "lodash";
 import { ZObject, Bundle } from "zapier-platform-core";
-import sample from "../samples/documentComment.json";
-import { getWebhookData, unsubscribeHook } from "../handleWebhook";
-import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
-import { fetchFromLinear } from "../fetchFromLinear";
-
-interface Comment {
-  id: string;
-  body: string;
-  url: string;
-  createdAt: string;
-  resolvedAt: string | null;
-  documentContent: {
-    project: {
-      id: string;
-      name: string;
-      url: string;
-    } | null;
-    document: {
-      id: string;
-      title: string;
-      project: {
-        id: string;
-        name: string;
-        url: string;
-      };
-    } | null;
-  };
-  user: {
-    id: string;
-    email: string;
-    name: string;
-    avatarUrl: string;
-  };
-  parent: {
-    id: string;
-    body: string;
-    createdAt: string;
-    user: {
-      id: string;
-      email: string;
-      name: string;
-      avatarUrl: string;
-    };
-  } | null;
-}
+import sample from "../samples/projectUpdateComment.json";
 
 interface CommentsResponse {
   data: {
     comments: {
-      nodes: Comment[];
+      nodes: {
+        id: string;
+        body: string;
+        url: string;
+        createdAt: string;
+        resolvedAt: string | null;
+        resolvingUser: {
+          id: string;
+          name: string;
+          email: string;
+          avatarUrl: string;
+        } | null;
+        project: {
+          id: string;
+          name: string;
+          url: string;
+        } | null;
+        documentContent: {
+          id: string;
+          createdAt: string;
+          document: {
+            id: string;
+            title: string;
+            project: {
+              id: string;
+              name: string;
+              url: string;
+            };
+          };
+        } | null;
+        user: {
+          id: string;
+          email: string;
+          name: string;
+          avatarUrl: string;
+        };
+        parent: {
+          id: string;
+          body: string;
+          createdAt: string;
+          user: {
+            id: string;
+            email: string;
+            name: string;
+            avatarUrl: string;
+          };
+        } | null;
+      }[];
+      pageInfo: {
+        hasNextPage: boolean;
+        endCursor: string;
+      };
     };
   };
 }
 
-/**
- * Sets up a new webhook subscription for document comments in Linear.
- * @see https://platform.zapier.com/build/cli-hook-trigger#1-write-the-subscribehook-function
- * @see https://platform.zapier.com/build/cli-hook-trigger#subscribehook
- */
-const subscribeHook = (z: ZObject, bundle: Bundle) => {
-  const data = {
-    url: bundle.targetUrl,
-    inputData:
-      bundle.inputData && Object.keys(bundle.inputData).length > 0
-        ? pick(bundle.inputData, ["creatorId", "projectId", "documentId"])
-        : undefined,
-  };
-
-  return z
-    .request({
-      url: "https://client-api.linear.app/connect/zapier/subscribe/commentDocument",
-      method: "POST",
-      body: data,
-    })
-    .then((response) => response.data);
-};
-
-/**
- * Fetches a list of comments from Linear to use as examples when building a Zap.
- * @see https://platform.zapier.com/build/cli-hook-trigger#4-write-the-performlist-function
- * @see https://platform.zapier.com/build/cli-hook-trigger#performlist
- */
 const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
-  const variables: Record<string, string> = {};
-  const variableSchema: Record<string, string> = {};
-  const filters: unknown[] = [{ documentContent: { null: false } }];
-  if (bundle.inputData.creatorId) {
-    variableSchema.creatorId = "ID";
-    variables.creatorId = bundle.inputData.creatorId;
-    filters.push({ user: { id: { eq: new VariableType("creatorId") } } });
-  }
-  if (bundle.inputData.projectId) {
-    variableSchema.projectId = "ID";
-    variables.projectId = bundle.inputData.projectId;
-    filters.push({
-      or: [
-        { documentContent: { project: { id: { eq: new VariableType("projectId") } } } },
-        { documentContent: { document: { project: { id: { eq: new VariableType("projectId") } } } } },
-      ],
-    });
-  }
-  if (bundle.inputData.documentId) {
-    variableSchema.documentId = "ID";
-    variables.documentId = bundle.inputData.documentId;
-    filters.push({ documentContent: { document: { id: { eq: new VariableType("documentId") } } } });
-  }
-  const filter = { and: filters };
+  const cursor = bundle.meta.page ? await z.cursor.get() : undefined;
 
-  const jsonQuery = {
-    query: {
-      __variables: variableSchema,
-      comments: {
-        __args: {
-          first: 25,
-          filter,
-        },
-        nodes: {
-          id: true,
-          body: true,
-          createdAt: true,
-          resolvedAt: true,
-          documentContent: {
-            project: {
-              id: true,
-              name: true,
-              url: true,
-            },
-            document: {
-              id: true,
-              title: true,
-              project: {
-                id: true,
-                name: true,
-                url: true,
-              },
-            },
-          },
-          user: {
-            id: true,
-            email: true,
-            name: true,
-            avatarUrl: true,
-          },
-          parent: {
-            id: true,
-            body: true,
-            createdAt: true,
-            user: {
-              id: true,
-              email: true,
-              name: true,
-              avatarUrl: true,
-            },
-          },
-        },
-      },
+  const variables = omitBy(
+    {
+      creatorId: bundle.inputData.creator_id,
+      projectId: bundle.inputData.project_id,
+      documentId: bundle.inputData.document_id,
+      after: cursor,
     },
-  };
+    (v) => v === undefined
+  );
 
-  const query = jsonToGraphQLQuery(jsonQuery);
-  const response = await fetchFromLinear(z, bundle, query, variables);
+  const filters = [];
+  if ("creatorId" in variables) {
+    filters.push(`{ user: { id: { eq: $creatorId } } }`);
+  }
+  if ("projectId" in variables) {
+    filters.push(`{ documentContent: { project: { id: { eq: $projectId }} } }`);
+    filters.push(`{ documentContent: { document: { project: { id: { eq: $projectId }}}}}`);
+  }
+  if ("documentId" in variables) {
+    filters.push(`{ documentContent: { document: { id: { eq: $documentId }}}}`);
+  }
+
+  const response = await z.request({
+    url: "https://api.linear.app/graphql",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      authorization: bundle.authData.api_key,
+    },
+    body: {
+      query: `
+      query ZapierListComments(
+        $after: String
+        ${"creatorId" in variables ? "$creatorId: ID" : ""}
+        ${"projectId" in variables ? "$projectId: ID" : ""}
+        ${"documentId" in variables ? "$documentId: ID" : ""}
+      ) {
+        comments(
+          first: 25
+          after: $after
+          ${
+            filters.length > 0
+              ? `
+          filter: {
+            and : [
+              ${filters.join("\n              ")}
+            ]
+          }`
+              : ""
+          }
+        ) {
+          nodes {
+            id
+            body
+            createdAt
+            resolvedAt
+            resolvingUser {
+              id
+              name
+              email
+              avatarUrl
+            }
+            documentContent {
+              id
+              createdAt
+              updatedAt
+              project {
+                id
+                name
+                url
+              }
+              document {
+                id
+                title
+                project {
+                  id
+                  name
+                  url
+                }
+              }
+            }
+            user {
+              id
+              email
+              name
+              avatarUrl
+            }
+            parent {
+              id
+              body
+              createdAt
+              user {
+                id
+                email
+                name
+                avatarUrl
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }`,
+      variables: variables,
+    },
+    method: "POST",
+  });
+
   const data = (response.json as CommentsResponse).data;
-  return data.comments.nodes;
+  const comments = data.comments.nodes;
+
+  // Set cursor for pagination
+  if (data.comments.pageInfo.hasNextPage) {
+    await z.cursor.set(data.comments.pageInfo.endCursor);
+  }
+
+  return comments.map((comment) => ({
+    ...comment,
+    id: `${comment.id}-${comment.createdAt}`,
+    commentId: comment.id,
+  }));
 };
 
-export const newDocumentCommentInstant = {
-  key: "newDocumentCommentV2",
+const comment = {
   noun: "Comment",
-  display: {
-    label: "New Document Comment",
-    description: "Triggers when a new document comment is created.",
-  },
+
   operation: {
     inputFields: [
       {
         required: false,
         label: "Creator",
-        key: "creatorId",
+        key: "creator_id",
         helpText: "Only trigger on document comments added by this user.",
         dynamic: "user.id.name",
         altersDynamicFields: true,
       },
       {
         required: false,
-        label: "Project",
-        key: "projectId",
-        helpText: "Only trigger on document comments tied to this project.",
-        dynamic: "projectWithoutTeam.id.name",
-        altersDynamicFields: true,
+        label: "Project ID",
+        key: "project_id",
+        helpText: "Only trigger on comments added to the documents in the project with this ID.",
       },
       {
         required: false,
         label: "Document ID",
-        key: "documentId",
+        key: "document_id",
         helpText: "Only trigger on comments added to the document with this ID.",
       },
     ],
-    type: "hook",
-    performSubscribe: subscribeHook,
-    performUnsubscribe: unsubscribeHook,
-    perform: getWebhookData,
-    performList: getCommentList(),
     sample,
+  },
+};
+
+export const newDocumentComment = {
+  ...comment,
+  key: "newDocumentComment",
+  display: {
+    label: "New Document Comment",
+    description: "Triggers when a new document comment is created.",
+    hidden: true,
+  },
+  operation: {
+    ...comment.operation,
+    perform: getCommentList(),
+    canPaginate: true,
   },
 };

--- a/src/triggers/commentDocumentV2.ts
+++ b/src/triggers/commentDocumentV2.ts
@@ -1,0 +1,207 @@
+import { pick } from "lodash";
+import { ZObject, Bundle } from "zapier-platform-core";
+import sample from "../samples/documentComment.json";
+import { getWebhookData, unsubscribeHook } from "../handleWebhook";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
+import { fetchFromLinear } from "../fetchFromLinear";
+
+interface Comment {
+  id: string;
+  body: string;
+  url: string;
+  createdAt: string;
+  resolvedAt: string | null;
+  documentContent: {
+    project: {
+      id: string;
+      name: string;
+      url: string;
+    } | null;
+    document: {
+      id: string;
+      title: string;
+      project: {
+        id: string;
+        name: string;
+        url: string;
+      };
+    } | null;
+  };
+  user: {
+    id: string;
+    email: string;
+    name: string;
+    avatarUrl: string;
+  };
+  parent: {
+    id: string;
+    body: string;
+    createdAt: string;
+    user: {
+      id: string;
+      email: string;
+      name: string;
+      avatarUrl: string;
+    };
+  } | null;
+}
+
+interface CommentsResponse {
+  data: {
+    comments: {
+      nodes: Comment[];
+    };
+  };
+}
+
+/**
+ * Sets up a new webhook subscription for document comments in Linear.
+ * @see https://platform.zapier.com/build/cli-hook-trigger#1-write-the-subscribehook-function
+ * @see https://platform.zapier.com/build/cli-hook-trigger#subscribehook
+ */
+const subscribeHook = (z: ZObject, bundle: Bundle) => {
+  const data = {
+    url: bundle.targetUrl,
+    inputData:
+      bundle.inputData && Object.keys(bundle.inputData).length > 0
+        ? pick(bundle.inputData, ["creatorId", "projectId", "documentId"])
+        : undefined,
+  };
+
+  return z
+    .request({
+      url: "https://client-api.linear.app/connect/zapier/subscribe/commentDocument",
+      method: "POST",
+      body: data,
+    })
+    .then((response) => response.data);
+};
+
+/**
+ * Fetches a list of comments from Linear to use as examples when building a Zap.
+ * @see https://platform.zapier.com/build/cli-hook-trigger#4-write-the-performlist-function
+ * @see https://platform.zapier.com/build/cli-hook-trigger#performlist
+ */
+const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
+  const variables: Record<string, string> = {};
+  const variableSchema: Record<string, string> = {};
+  const filters: unknown[] = [{ documentContent: { null: false } }];
+  if (bundle.inputData.creatorId) {
+    variableSchema.creatorId = "ID";
+    variables.creatorId = bundle.inputData.creatorId;
+    filters.push({ user: { id: { eq: new VariableType("creatorId") } } });
+  }
+  if (bundle.inputData.projectId) {
+    variableSchema.projectId = "ID";
+    variables.projectId = bundle.inputData.projectId;
+    filters.push({
+      or: [
+        { documentContent: { project: { id: { eq: new VariableType("projectId") } } } },
+        { documentContent: { document: { project: { id: { eq: new VariableType("projectId") } } } } },
+      ],
+    });
+  }
+  if (bundle.inputData.documentId) {
+    variableSchema.documentId = "ID";
+    variables.documentId = bundle.inputData.documentId;
+    filters.push({ documentContent: { document: { id: { eq: new VariableType("documentId") } } } });
+  }
+  const filter = { and: filters };
+
+  const jsonQuery = {
+    query: {
+      __variables: variableSchema,
+      comments: {
+        __args: {
+          first: 25,
+          filter,
+        },
+        nodes: {
+          id: true,
+          body: true,
+          createdAt: true,
+          resolvedAt: true,
+          documentContent: {
+            project: {
+              id: true,
+              name: true,
+              url: true,
+            },
+            document: {
+              id: true,
+              title: true,
+              project: {
+                id: true,
+                name: true,
+                url: true,
+              },
+            },
+          },
+          user: {
+            id: true,
+            email: true,
+            name: true,
+            avatarUrl: true,
+          },
+          parent: {
+            id: true,
+            body: true,
+            createdAt: true,
+            user: {
+              id: true,
+              email: true,
+              name: true,
+              avatarUrl: true,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const query = jsonToGraphQLQuery(jsonQuery);
+  const response = await fetchFromLinear(z, bundle, query, variables);
+  const data = (response.json as CommentsResponse).data;
+  return data.comments.nodes;
+};
+
+export const newDocumentCommentInstant = {
+  key: "newDocumentCommentV2",
+  noun: "Comment",
+  display: {
+    label: "New Document Comment",
+    description: "Triggers when a new document comment is created.",
+  },
+  operation: {
+    inputFields: [
+      {
+        required: false,
+        label: "Creator",
+        key: "creatorId",
+        helpText: "Only trigger on document comments added by this user.",
+        dynamic: "user.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Project",
+        key: "projectId",
+        helpText: "Only trigger on document comments tied to this project.",
+        dynamic: "projectWithoutTeam.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Document ID",
+        key: "documentId",
+        helpText: "Only trigger on comments added to the document with this ID.",
+      },
+    ],
+    type: "hook",
+    performSubscribe: subscribeHook,
+    performUnsubscribe: unsubscribeHook,
+    perform: getWebhookData,
+    performList: getCommentList(),
+    sample,
+  },
+};

--- a/src/triggers/commentIssue.ts
+++ b/src/triggers/commentIssue.ts
@@ -1,181 +1,219 @@
-import { pick } from "lodash";
+import { omitBy } from "lodash";
 import { ZObject, Bundle } from "zapier-platform-core";
 import sample from "../samples/issueComment.json";
-import { getWebhookData, unsubscribeHook } from "../handleWebhook";
-import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
-import { fetchFromLinear } from "../fetchFromLinear";
-
-interface Comment {
-  id: string;
-  body: string;
-  url: string;
-  createdAt: string;
-  resolvedAt: string | null;
-  issue: {
-    id: string;
-    identifier: string;
-    title: string;
-    url: string;
-    team: {
-      id: string;
-      key: string;
-      name: string;
-    };
-  };
-  user: {
-    id: string;
-    email: string;
-    name: string;
-    avatarUrl: string;
-  };
-  parent: {
-    id: string;
-    body: string;
-    createdAt: string;
-    user: {
-      id: string;
-      email: string;
-      name: string;
-      avatarUrl: string;
-    };
-  } | null;
-}
 
 interface CommentsResponse {
   data: {
     comments: {
-      nodes: Comment[];
+      nodes: {
+        id: string;
+        body: string;
+        url: string;
+        createdAt: string;
+        resolvedAt: string | null;
+        resolvingUser: {
+          id: string;
+          name: string;
+          email: string;
+          avatarUrl: string;
+        } | null;
+        issue: {
+          id: string;
+          identifier: string;
+          title: string;
+          url: string;
+          team: {
+            id: string;
+            name: string;
+          };
+        };
+        user: {
+          id: string;
+          email: string;
+          name: string;
+          avatarUrl: string;
+        };
+        parent: {
+          id: string;
+          body: string;
+          createdAt: string;
+          user: {
+            id: string;
+            email: string;
+            name: string;
+            avatarUrl: string;
+          };
+        } | null;
+      }[];
+      pageInfo: {
+        hasNextPage: boolean;
+        endCursor: string;
+      };
     };
   };
 }
 
-const subscribeHook = (z: ZObject, bundle: Bundle) => {
-  const data = {
-    url: bundle.targetUrl,
-    inputData:
-      bundle.inputData && Object.keys(bundle.inputData).length > 0
-        ? pick(bundle.inputData, ["creatorId", "teamId", "issueId"])
-        : undefined,
-  };
-
-  return z
-    .request({
-      url: "https://client-api.linear.app/connect/zapier/subscribe/commentIssue",
-      method: "POST",
-      body: data,
-    })
-    .then((response) => response.data);
-};
-
 const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
-  const variables: Record<string, string> = {};
-  const variableSchema: Record<string, string> = {};
-  const filters: unknown[] = [{ issue: { null: false } }];
-  if (bundle.inputData.creatorId) {
-    variableSchema.creatorId = "ID";
-    variables.creatorId = bundle.inputData.creatorId;
-    filters.push({ user: { id: { eq: new VariableType("creatorId") } } });
-  }
-  if (bundle.inputData.teamId) {
-    variableSchema.teamId = "ID";
-    variables.teamId = bundle.inputData.teamId;
-    filters.push({ issue: { team: { id: { eq: new VariableType("teamId") } } } });
-  }
-  if (bundle.inputData.issueId) {
-    variableSchema.issueId = "ID";
-    variables.issueId = bundle.inputData.issueId;
-    filters.push({ issue: { id: { eq: new VariableType("issueId") } } });
-  }
-  const filter = { and: filters };
+  const cursor = bundle.meta.page ? await z.cursor.get() : undefined;
 
-  const jsonQuery = {
-    query: {
-      __variables: variableSchema,
-      comments: {
-        __args: {
-          first: 25,
-          filter,
-        },
-        nodes: {
-          id: true,
-          body: true,
-          createdAt: true,
-          resolvedAt: true,
-          issue: {
-            id: true,
-            identifier: true,
-            title: true,
-            url: true,
-            team: {
-              id: true,
-              key: true,
-              name: true,
-            },
-          },
-          user: {
-            id: true,
-            email: true,
-            name: true,
-            avatarUrl: true,
-          },
-          parent: {
-            id: true,
-            body: true,
-            createdAt: true,
-            user: {
-              id: true,
-              email: true,
-              name: true,
-              avatarUrl: true,
-            },
-          },
-        },
-      },
+  const variables = omitBy(
+    {
+      creatorId: bundle.inputData.creator_id,
+      teamId: bundle.inputData.team_id,
+      issueId: bundle.inputData.issue,
+      after: cursor,
     },
-  };
-  const query = jsonToGraphQLQuery(jsonQuery);
-  const response = await fetchFromLinear(z, bundle, query, variables);
+    (v) => v === undefined
+  );
+
+  const filters = [];
+  if ("creatorId" in variables) {
+    filters.push(`{ user: { id: { eq: $creatorId } } }`);
+  }
+  if ("teamId" in variables) {
+    filters.push(`{ issue: { team: { id: { eq: $teamId } } } }`);
+  }
+  if ("issueId" in variables) {
+    filters.push(`{ issue: { id: { eq: $issueId } } }`);
+  }
+
+  const response = await z.request({
+    url: "https://api.linear.app/graphql",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      authorization: bundle.authData.api_key,
+    },
+    body: {
+      query: `
+      query ZapierListComments(
+        $after: String
+        ${"creatorId" in variables ? "$creatorId: ID" : ""}
+        ${"teamId" in variables ? "$teamId: ID" : ""}
+        ${"issueId" in variables ? "$issueId: ID" : ""}
+      ) {
+        comments(
+          first: 25
+          after: $after
+          ${
+            filters.length > 0
+              ? `
+          filter: {
+            and : [
+              ${filters.join("\n              ")}
+            ]
+          }`
+              : ""
+          }
+        ) {
+          nodes {
+            id
+            body
+            createdAt
+            resolvedAt
+            resolvingUser {
+              id
+              name
+              email
+              avatarUrl
+            }
+            issue {
+              id
+              identifier
+              title
+              url
+              team {
+                id
+                name
+              }
+            }
+            user {
+              id
+              email
+              name
+              avatarUrl
+            }
+            parent {
+              id
+              body
+              createdAt
+              user {
+                id
+                email
+                name
+                avatarUrl
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }`,
+      variables: variables,
+    },
+    method: "POST",
+  });
+
   const data = (response.json as CommentsResponse).data;
-  return data.comments.nodes;
+  const comments = data.comments.nodes;
+
+  // Set cursor for pagination
+  if (data.comments.pageInfo.hasNextPage) {
+    await z.cursor.set(data.comments.pageInfo.endCursor);
+  }
+
+  return comments.map((comment) => ({
+    ...comment,
+    id: `${comment.id}-${comment.createdAt}`,
+    commentId: comment.id,
+  }));
 };
 
-export const newIssueCommentInstant = {
-  key: "newIssueCommentInstant",
+const comment = {
   noun: "Comment",
-  display: {
-    label: "New Issue Comment",
-    description: "Triggers when a new issue comment is created.",
-  },
+
   operation: {
     inputFields: [
       {
         required: false,
+        label: "Team",
+        key: "team_id",
+        helpText: "Only trigger on issue comments created to this team.",
+        dynamic: "team.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
         label: "Creator",
-        key: "creatorId",
+        key: "creator_id",
         helpText: "Only trigger on issue comments added by this user.",
         dynamic: "user.id.name",
         altersDynamicFields: true,
       },
       {
         required: false,
-        label: "Team",
-        key: "teamId",
-        helpText: "Only trigger on issue comments created in this team.",
-        dynamic: "team.id.name",
-        altersDynamicFields: true,
-      },
-      {
-        required: false,
         label: "Issue ID",
-        key: "issueId",
+        key: "issue",
         helpText: "Only trigger on comments added to this issue identified by its ID.",
       },
     ],
-    type: "hook",
-    performSubscribe: subscribeHook,
-    performUnsubscribe: unsubscribeHook,
-    perform: getWebhookData,
-    performList: getCommentList(),
     sample,
+  },
+};
+
+export const newIssueComment = {
+  ...comment,
+  key: "newComment",
+  display: {
+    label: "New Issue Comment",
+    description: "Triggers when a new issue comment is created.",
+    hidden: true,
+  },
+  operation: {
+    ...comment.operation,
+    perform: getCommentList(),
+    canPaginate: true,
   },
 };

--- a/src/triggers/commentIssueV2.ts
+++ b/src/triggers/commentIssueV2.ts
@@ -1,0 +1,181 @@
+import { pick } from "lodash";
+import { ZObject, Bundle } from "zapier-platform-core";
+import sample from "../samples/issueComment.json";
+import { getWebhookData, unsubscribeHook } from "../handleWebhook";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
+import { fetchFromLinear } from "../fetchFromLinear";
+
+interface Comment {
+  id: string;
+  body: string;
+  url: string;
+  createdAt: string;
+  resolvedAt: string | null;
+  issue: {
+    id: string;
+    identifier: string;
+    title: string;
+    url: string;
+    team: {
+      id: string;
+      key: string;
+      name: string;
+    };
+  };
+  user: {
+    id: string;
+    email: string;
+    name: string;
+    avatarUrl: string;
+  };
+  parent: {
+    id: string;
+    body: string;
+    createdAt: string;
+    user: {
+      id: string;
+      email: string;
+      name: string;
+      avatarUrl: string;
+    };
+  } | null;
+}
+
+interface CommentsResponse {
+  data: {
+    comments: {
+      nodes: Comment[];
+    };
+  };
+}
+
+const subscribeHook = (z: ZObject, bundle: Bundle) => {
+  const data = {
+    url: bundle.targetUrl,
+    inputData:
+      bundle.inputData && Object.keys(bundle.inputData).length > 0
+        ? pick(bundle.inputData, ["creatorId", "teamId", "issueId"])
+        : undefined,
+  };
+
+  return z
+    .request({
+      url: "https://client-api.linear.app/connect/zapier/subscribe/commentIssue",
+      method: "POST",
+      body: data,
+    })
+    .then((response) => response.data);
+};
+
+const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
+  const variables: Record<string, string> = {};
+  const variableSchema: Record<string, string> = {};
+  const filters: unknown[] = [{ issue: { null: false } }];
+  if (bundle.inputData.creatorId) {
+    variableSchema.creatorId = "ID";
+    variables.creatorId = bundle.inputData.creatorId;
+    filters.push({ user: { id: { eq: new VariableType("creatorId") } } });
+  }
+  if (bundle.inputData.teamId) {
+    variableSchema.teamId = "ID";
+    variables.teamId = bundle.inputData.teamId;
+    filters.push({ issue: { team: { id: { eq: new VariableType("teamId") } } } });
+  }
+  if (bundle.inputData.issueId) {
+    variableSchema.issueId = "ID";
+    variables.issueId = bundle.inputData.issueId;
+    filters.push({ issue: { id: { eq: new VariableType("issueId") } } });
+  }
+  const filter = { and: filters };
+
+  const jsonQuery = {
+    query: {
+      __variables: variableSchema,
+      comments: {
+        __args: {
+          first: 25,
+          filter,
+        },
+        nodes: {
+          id: true,
+          body: true,
+          createdAt: true,
+          resolvedAt: true,
+          issue: {
+            id: true,
+            identifier: true,
+            title: true,
+            url: true,
+            team: {
+              id: true,
+              key: true,
+              name: true,
+            },
+          },
+          user: {
+            id: true,
+            email: true,
+            name: true,
+            avatarUrl: true,
+          },
+          parent: {
+            id: true,
+            body: true,
+            createdAt: true,
+            user: {
+              id: true,
+              email: true,
+              name: true,
+              avatarUrl: true,
+            },
+          },
+        },
+      },
+    },
+  };
+  const query = jsonToGraphQLQuery(jsonQuery);
+  const response = await fetchFromLinear(z, bundle, query, variables);
+  const data = (response.json as CommentsResponse).data;
+  return data.comments.nodes;
+};
+
+export const newIssueCommentInstant = {
+  key: "newIssueCommentInstant",
+  noun: "Comment",
+  display: {
+    label: "New Issue Comment",
+    description: "Triggers when a new issue comment is created.",
+  },
+  operation: {
+    inputFields: [
+      {
+        required: false,
+        label: "Creator",
+        key: "creatorId",
+        helpText: "Only trigger on issue comments added by this user.",
+        dynamic: "user.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Team",
+        key: "teamId",
+        helpText: "Only trigger on issue comments created in this team.",
+        dynamic: "team.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Issue ID",
+        key: "issueId",
+        helpText: "Only trigger on comments added to this issue identified by its ID.",
+      },
+    ],
+    type: "hook",
+    performSubscribe: subscribeHook,
+    performUnsubscribe: unsubscribeHook,
+    perform: getWebhookData,
+    performList: getCommentList(),
+    sample,
+  },
+};

--- a/src/triggers/commentProjectUpdate.ts
+++ b/src/triggers/commentProjectUpdate.ts
@@ -1,180 +1,218 @@
-import { pick } from "lodash";
+import { omitBy } from "lodash";
 import { ZObject, Bundle } from "zapier-platform-core";
-import sample from "../samples/issueComment.json";
-import { getWebhookData, unsubscribeHook } from "../handleWebhook";
-import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
-import { fetchFromLinear } from "../fetchFromLinear";
-
-interface Comment {
-  id: string;
-  body: string;
-  url: string;
-  createdAt: string;
-  resolvedAt: string | null;
-  projectUpdate: {
-    id: string;
-    body: string;
-    user: {
-      id: string;
-      name: string;
-      email: string;
-      avatarUrl: string;
-    };
-    url: string;
-    project: {
-      id: string;
-      name: string;
-      url: string;
-    };
-  };
-  user: {
-    id: string;
-    email: string;
-    name: string;
-    avatarUrl: string;
-  };
-  parent: {
-    id: string;
-    body: string;
-    createdAt: string;
-    user: {
-      id: string;
-      email: string;
-      name: string;
-      avatarUrl: string;
-    };
-  } | null;
-}
+import sample from "../samples/projectUpdateComment.json";
 
 interface CommentsResponse {
   data: {
     comments: {
-      nodes: Comment[];
+      nodes: {
+        id: string;
+        body: string;
+        url: string;
+        createdAt: string;
+        resolvedAt: string | null;
+        resolvingUser: {
+          id: string;
+          name: string;
+          email: string;
+          avatarUrl: string;
+        } | null;
+        projectUpdate: {
+          id: string;
+          body: string;
+          user: {
+            id: string;
+            name: string;
+            email: string;
+            avatarUrl: string;
+          };
+          url: string;
+          project: {
+            id: string;
+            name: string;
+            url: string;
+          };
+        };
+        user: {
+          id: string;
+          email: string;
+          name: string;
+          avatarUrl: string;
+        };
+        parent: {
+          id: string;
+          body: string;
+          createdAt: string;
+          user: {
+            id: string;
+            email: string;
+            name: string;
+            avatarUrl: string;
+          };
+        } | null;
+      }[];
+      pageInfo: {
+        hasNextPage: boolean;
+        endCursor: string;
+      };
     };
   };
 }
 
-const subscribeHook = (z: ZObject, bundle: Bundle) => {
-  const data = {
-    url: bundle.targetUrl,
-    inputData:
-      bundle.inputData && Object.keys(bundle.inputData).length > 0
-        ? pick(bundle.inputData, ["creatorId", "projectId"])
-        : undefined,
-  };
-
-  return z
-    .request({
-      url: "https://client-api.linear.app/connect/zapier/subscribe/commentProjectUpdate",
-      method: "POST",
-      body: data,
-    })
-    .then((response) => response.data);
-};
-
 const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
-  const variables: Record<string, string> = {};
-  const variableSchema: Record<string, string> = {};
-  const filters: unknown[] = [{ projectUpdate: { null: false } }];
-  if (bundle.inputData.creatorId) {
-    variableSchema.creatorId = "ID";
-    variables.creatorId = bundle.inputData.creatorId;
-    filters.push({ user: { id: { eq: new VariableType("creatorId") } } });
-  }
-  if (bundle.inputData.projectId) {
-    variableSchema.projectId = "ID";
-    variables.projectId = bundle.inputData.projectId;
-    filters.push({ projectUpdate: { project: { id: { eq: new VariableType("projectId") } } } });
-  }
-  const filter = { and: filters };
+  const cursor = bundle.meta.page ? await z.cursor.get() : undefined;
 
-  const jsonQuery = {
-    query: {
-      __variables: variableSchema,
-      comments: {
-        __args: {
-          first: 25,
-          filter,
-        },
-        nodes: {
-          id: true,
-          body: true,
-          createdAt: true,
-          resolvedAt: true,
-          projectUpdate: {
-            id: true,
-            body: true,
-            user: {
-              id: true,
-              email: true,
-              name: true,
-              avatarUrl: true,
-            },
-            url: true,
-            project: {
-              id: true,
-              name: true,
-              url: true,
-            },
-          },
-          user: {
-            id: true,
-            email: true,
-            name: true,
-            avatarUrl: true,
-          },
-          parent: {
-            id: true,
-            body: true,
-            createdAt: true,
-            user: {
-              id: true,
-              email: true,
-              name: true,
-              avatarUrl: true,
-            },
-          },
-        },
-      },
+  const variables = omitBy(
+    {
+      creatorId: bundle.inputData.creator_id,
+      projectId: bundle.inputData.project_id,
+      after: cursor,
     },
-  };
-  const query = jsonToGraphQLQuery(jsonQuery);
-  const response = await fetchFromLinear(z, bundle, query, variables);
+    (v) => v === undefined
+  );
+
+  const filters = [];
+  if ("creatorId" in variables) {
+    filters.push(`{ user: { id: { eq: $creatorId } } }`);
+  }
+  if ("projectId" in variables) {
+    filters.push(`{ projectUpdate: { project: { id: { eq: $projectId } } } }`);
+  }
+
+  const response = await z.request({
+    url: "https://api.linear.app/graphql",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      authorization: bundle.authData.api_key,
+    },
+    body: {
+      query: `
+      query ZapierListComments(
+        $after: String
+        ${"creatorId" in variables ? "$creatorId: ID" : ""}
+        ${"projectId" in variables ? "$projectId: ID" : ""}
+      ) {
+        comments(
+          first: 25
+          after: $after
+          ${
+            filters.length > 0
+              ? `
+          filter: {
+            and : [
+              ${filters.join("\n              ")}
+            ]
+          }`
+              : ""
+          }
+        ) {
+          nodes {
+            id
+            body
+            createdAt
+            resolvedAt
+            resolvingUser {
+              id
+              name
+              email
+              avatarUrl
+            }
+            projectUpdate {
+              id
+              body
+              user {
+                id
+                name
+                email
+                avatarUrl
+              }
+              url
+              project {
+                id
+                name
+                url
+              }
+            }
+            user {
+              id
+              email
+              name
+              avatarUrl
+            }
+            parent {
+              id
+              body
+              createdAt
+              user {
+                id
+                email
+                name
+                avatarUrl
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }`,
+      variables: variables,
+    },
+    method: "POST",
+  });
+
   const data = (response.json as CommentsResponse).data;
-  return data.comments.nodes;
+  const comments = data.comments.nodes;
+
+  // Set cursor for pagination
+  if (data.comments.pageInfo.hasNextPage) {
+    await z.cursor.set(data.comments.pageInfo.endCursor);
+  }
+
+  return comments.map((comment) => ({
+    ...comment,
+    id: `${comment.id}-${comment.createdAt}`,
+    commentId: comment.id,
+  }));
 };
 
-export const newProjectUpdateCommentInstant = {
-  key: "newProjectUpdateCommentInstant",
+const comment = {
   noun: "Comment",
-  display: {
-    label: "New Project Update Comment",
-    description: "Triggers when a new project update comment is created.",
-  },
+
   operation: {
     inputFields: [
       {
         required: false,
         label: "Creator",
-        key: "creatorId",
+        key: "creator_id",
         helpText: "Only trigger on project update comments added by this user.",
         dynamic: "user.id.name",
         altersDynamicFields: true,
       },
       {
         required: false,
-        label: "Project",
-        key: "projectId",
-        helpText: "Only trigger on project update comments tied to this project.",
-        dynamic: "projectWithoutTeam.id.name",
-        altersDynamicFields: true,
+        label: "Project ID",
+        key: "project_id",
+        helpText: "Only trigger on project update comments added to this project identified by its ID",
       },
     ],
-    type: "hook",
-    performSubscribe: subscribeHook,
-    performUnsubscribe: unsubscribeHook,
-    perform: getWebhookData,
-    performList: getCommentList(),
     sample,
+  },
+};
+
+export const newProjectUpdateComment = {
+  ...comment,
+  key: "newProjectUpdateComment",
+  display: {
+    label: "New Project Update Comment",
+    description: "Triggers when a new project update comment is created.",
+    hidden: true,
+  },
+  operation: {
+    ...comment.operation,
+    perform: getCommentList(),
+    canPaginate: true,
   },
 };

--- a/src/triggers/commentProjectUpdateV2.ts
+++ b/src/triggers/commentProjectUpdateV2.ts
@@ -1,0 +1,180 @@
+import { pick } from "lodash";
+import { ZObject, Bundle } from "zapier-platform-core";
+import sample from "../samples/issueComment.json";
+import { getWebhookData, unsubscribeHook } from "../handleWebhook";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
+import { fetchFromLinear } from "../fetchFromLinear";
+
+interface Comment {
+  id: string;
+  body: string;
+  url: string;
+  createdAt: string;
+  resolvedAt: string | null;
+  projectUpdate: {
+    id: string;
+    body: string;
+    user: {
+      id: string;
+      name: string;
+      email: string;
+      avatarUrl: string;
+    };
+    url: string;
+    project: {
+      id: string;
+      name: string;
+      url: string;
+    };
+  };
+  user: {
+    id: string;
+    email: string;
+    name: string;
+    avatarUrl: string;
+  };
+  parent: {
+    id: string;
+    body: string;
+    createdAt: string;
+    user: {
+      id: string;
+      email: string;
+      name: string;
+      avatarUrl: string;
+    };
+  } | null;
+}
+
+interface CommentsResponse {
+  data: {
+    comments: {
+      nodes: Comment[];
+    };
+  };
+}
+
+const subscribeHook = (z: ZObject, bundle: Bundle) => {
+  const data = {
+    url: bundle.targetUrl,
+    inputData:
+      bundle.inputData && Object.keys(bundle.inputData).length > 0
+        ? pick(bundle.inputData, ["creatorId", "projectId"])
+        : undefined,
+  };
+
+  return z
+    .request({
+      url: "https://client-api.linear.app/connect/zapier/subscribe/commentProjectUpdate",
+      method: "POST",
+      body: data,
+    })
+    .then((response) => response.data);
+};
+
+const getCommentList = () => async (z: ZObject, bundle: Bundle) => {
+  const variables: Record<string, string> = {};
+  const variableSchema: Record<string, string> = {};
+  const filters: unknown[] = [{ projectUpdate: { null: false } }];
+  if (bundle.inputData.creatorId) {
+    variableSchema.creatorId = "ID";
+    variables.creatorId = bundle.inputData.creatorId;
+    filters.push({ user: { id: { eq: new VariableType("creatorId") } } });
+  }
+  if (bundle.inputData.projectId) {
+    variableSchema.projectId = "ID";
+    variables.projectId = bundle.inputData.projectId;
+    filters.push({ projectUpdate: { project: { id: { eq: new VariableType("projectId") } } } });
+  }
+  const filter = { and: filters };
+
+  const jsonQuery = {
+    query: {
+      __variables: variableSchema,
+      comments: {
+        __args: {
+          first: 25,
+          filter,
+        },
+        nodes: {
+          id: true,
+          body: true,
+          createdAt: true,
+          resolvedAt: true,
+          projectUpdate: {
+            id: true,
+            body: true,
+            user: {
+              id: true,
+              email: true,
+              name: true,
+              avatarUrl: true,
+            },
+            url: true,
+            project: {
+              id: true,
+              name: true,
+              url: true,
+            },
+          },
+          user: {
+            id: true,
+            email: true,
+            name: true,
+            avatarUrl: true,
+          },
+          parent: {
+            id: true,
+            body: true,
+            createdAt: true,
+            user: {
+              id: true,
+              email: true,
+              name: true,
+              avatarUrl: true,
+            },
+          },
+        },
+      },
+    },
+  };
+  const query = jsonToGraphQLQuery(jsonQuery);
+  const response = await fetchFromLinear(z, bundle, query, variables);
+  const data = (response.json as CommentsResponse).data;
+  return data.comments.nodes;
+};
+
+export const newProjectUpdateCommentInstant = {
+  key: "newProjectUpdateCommentInstant",
+  noun: "Comment",
+  display: {
+    label: "New Project Update Comment",
+    description: "Triggers when a new project update comment is created.",
+  },
+  operation: {
+    inputFields: [
+      {
+        required: false,
+        label: "Creator",
+        key: "creatorId",
+        helpText: "Only trigger on project update comments added by this user.",
+        dynamic: "user.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Project",
+        key: "projectId",
+        helpText: "Only trigger on project update comments tied to this project.",
+        dynamic: "projectWithoutTeam.id.name",
+        altersDynamicFields: true,
+      },
+    ],
+    type: "hook",
+    performSubscribe: subscribeHook,
+    performUnsubscribe: unsubscribeHook,
+    perform: getWebhookData,
+    performList: getCommentList(),
+    sample,
+  },
+};

--- a/src/triggers/issue.ts
+++ b/src/triggers/issue.ts
@@ -1,377 +1,320 @@
-import { omitBy, pick } from "lodash";
+import { omitBy } from "lodash";
 import { ZObject, Bundle } from "zapier-platform-core";
 import sample from "../samples/issue.json";
-import { unsubscribeHook } from "../handleWebhook";
-import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
-import { fetchFromLinear } from "../fetchFromLinear";
-
-export interface IssueCommon {
-  id: string;
-  identifier: string;
-  url: string;
-  title: string;
-  description: string;
-  priority: string;
-  estimate?: number;
-  dueDate?: Date;
-  slaBreachesAt?: Date;
-  slaStartedAt?: Date;
-  createdAt: Date;
-  updatedAt: Date;
-  project?: {
-    id: string;
-    name: string;
-  };
-  projectMilestone?: {
-    id: string;
-    name: string;
-  };
-  creator: {
-    id: string;
-    name: string;
-    email: string;
-  };
-  assignee?: {
-    id: string;
-    name: string;
-    email: string;
-  };
-  state: {
-    id: string;
-    name: string;
-    type: string;
-  };
-  parent?: {
-    id: string;
-    identifier: string;
-    url: string;
-    title: string;
-  };
-}
-
-interface IssueApi extends IssueCommon {
-  labels?: {
-    nodes: {
-      id: string;
-      color: string;
-      name: string;
-      parent?: {
-        id: string;
-      };
-    }[];
-  };
-}
-
-interface IssueWebhook extends IssueCommon {
-  labels?: {
-    id: string;
-    color: string;
-    name: string;
-    parentId?: string;
-  }[];
-}
 
 interface TeamIssuesResponse {
   data: {
     team: {
       issues: {
-        nodes: IssueApi[];
+        nodes: {
+          id: string;
+          identifier: string;
+          url: string;
+          title: string;
+          description: string;
+          priority: string;
+          estimate: number;
+          dueDate?: Date;
+          slaBreachesAt?: Date;
+          slaStartedAt?: Date;
+          createdAt: Date;
+          updatedAt: Date;
+          project?: {
+            id: string;
+            name: string;
+          };
+          projectMilestone?: {
+            id: string;
+            name: string;
+          };
+          creator: {
+            id: string;
+            name: string;
+            email: string;
+          };
+          assignee?: {
+            id: string;
+            name: string;
+            email: string;
+          };
+          status: {
+            id: string;
+            name: string;
+            type: string;
+          };
+          parent?: {
+            id: string;
+            identifier: string;
+            url: string;
+            title: string;
+          };
+        }[];
+        pageInfo: {
+          hasNextPage: boolean;
+          endCursor: string;
+        };
       };
     };
   };
 }
 
-const subscribeHook = (eventType: "create" | "update") => async (z: ZObject, bundle: Bundle) => {
-  if (!bundle.inputData.teamId) {
-    throw new z.errors.HaltedError("You must select a team");
+const buildIssueList = (orderBy: "createdAt" | "updatedAt") => async (z: ZObject, bundle: Bundle) => {
+  if (!bundle.inputData.team_id) {
+    throw new z.errors.HaltedError(`Please select the team first`);
   }
 
-  const inputData =
-    bundle.inputData && Object.keys(bundle.inputData).length > 0
-      ? omitBy(
-          {
-            ...pick(bundle.inputData, [
-              "teamId",
-              "statusId",
-              "creatorId",
-              "assigneeId",
-              "labelId",
-              "projectId",
-              "projectMilestoneId",
-            ]),
-            priority: bundle.inputData.priority ? Number(bundle.inputData.priority) : undefined,
-          },
-          (v) => v === undefined
-        )
-      : undefined;
+  const cursor = bundle.meta.page ? await z.cursor.get() : undefined;
 
-  const data = {
-    url: bundle.targetUrl,
-    inputData,
-  };
+  const variables = omitBy(
+    {
+      after: cursor,
+      teamId: bundle.inputData.team_id,
+      statusId: bundle.inputData.status_id,
+      creatorId: bundle.inputData.creator_id,
+      assigneeId: bundle.inputData.assignee_id,
+      priority: (bundle.inputData.priority && Number(bundle.inputData.priority)) || undefined,
+      labelId: bundle.inputData.label_id,
+      projectId: bundle.inputData.project_id,
+      projectMilestoneId: bundle.inputData.project_milestone_id,
+      orderBy,
+    },
+    (v) => v === undefined
+  );
 
-  const webhookType = eventType === "create" ? "createIssue" : "updateIssue";
-  return z
-    .request({
-      url: `https://client-api.linear.app/connect/zapier/subscribe/${webhookType}`,
-      method: "POST",
-      body: data,
-    })
-    .then((response) => response.data);
-};
-
-const getIssueList =
-  () =>
-  async (z: ZObject, bundle: Bundle): Promise<IssueWebhook[]> => {
-    if (!bundle.inputData.teamId) {
-      throw new z.errors.HaltedError("You must select a team");
-    }
-
-    const variables: Record<string, string | Number> = {};
-    const variableSchema: Record<string, string> = {};
-
-    variableSchema.teamId = "String!";
-    variables.teamId = bundle.inputData.teamId;
-
-    const filters: unknown[] = [];
-    if (bundle.inputData.priority) {
-      variableSchema.priority = "Float";
-      variables.priority = Number(bundle.inputData.priority);
-      filters.push({ priority: { eq: new VariableType("priority") } });
-    }
-    if (bundle.inputData.statusId) {
-      variableSchema.statusId = "ID";
-      variables.statusId = bundle.inputData.statusId;
-      filters.push({ state: { id: { eq: new VariableType("statusId") } } });
-    }
-    if (bundle.inputData.creatorId) {
-      variableSchema.creatorId = "ID";
-      variables.creatorId = bundle.inputData.creatorId;
-      filters.push({ creator: { id: { eq: new VariableType("creatorId") } } });
-    }
-    if (bundle.inputData.assigneeId) {
-      variableSchema.assigneeId = "ID";
-      variables.assigneeId = bundle.inputData.assigneeId;
-      filters.push({ assignee: { id: { eq: new VariableType("assigneeId") } } });
-    }
-    if (bundle.inputData.projectId) {
-      variableSchema.projectId = "ID";
-      variables.projectId = bundle.inputData.projectId;
-      filters.push({ project: { id: { eq: new VariableType("projectId") } } });
-    }
-    if (bundle.inputData.projectMilestoneId) {
-      variableSchema.projectMilestoneId = "ID";
-      variables.projectMilestoneId = bundle.inputData.projectMilestoneId;
-      filters.push({ projectMilestone: { id: { eq: new VariableType("projectMilestoneId") } } });
-    }
-    if (bundle.inputData.labelId) {
-      variableSchema.labelId = "ID";
-      variables.labelId = bundle.inputData.labelId;
-      filters.push({ labels: { id: { eq: new VariableType("labelId") } } });
-    }
-    const filter = { and: filters };
-
-    const jsonQuery = {
-      query: {
-        __variables: variableSchema,
-        team: {
-          __args: {
-            id: new VariableType("teamId"),
-          },
-          issues: {
-            __args: {
-              first: 10,
-              filter,
-            },
-            nodes: {
-              id: true,
-              identifier: true,
-              url: true,
-              title: true,
-              description: true,
-              priority: true,
-              estimate: true,
-              dueDate: true,
-              slaBreachesAt: true,
-              slaStartedAt: true,
-              createdAt: true,
-              updatedAt: true,
-              project: {
-                id: true,
-                name: true,
-              },
-              projectMilestone: {
-                id: true,
-                name: true,
-              },
-              creator: {
-                id: true,
-                name: true,
-                email: true,
-              },
-              assignee: {
-                id: true,
-                name: true,
-                email: true,
-              },
-              state: {
-                id: true,
-                name: true,
-                type: true,
-              },
-              parent: {
-                id: true,
-                identifier: true,
-                url: true,
-                title: true,
-              },
-              labels: {
-                nodes: {
-                  id: true,
-                  color: true,
-                  name: true,
-                  parent: {
-                    id: true,
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    };
-    const query = jsonToGraphQLQuery(jsonQuery);
-    const response = await fetchFromLinear(z, bundle, query, variables);
-    const data = (response.json as TeamIssuesResponse).data;
-    const issuesRaw = data.team.issues.nodes;
-    // We need to map the API schema to the webhook schema
-    return issuesRaw.map((issueRaw) => ({
-      ...issueRaw,
-      labels: issueRaw.labels?.nodes.map((label) => ({
-        id: label.id,
-        color: label.color,
-        name: label.name,
-        parentId: label.parent?.id,
-      })),
-    }));
-  };
-
-const getWebhookDataForIssue = (z: ZObject, bundle: Bundle) => {
-  const entity = {
-    ...bundle.cleanedRequest.data,
-    querystring: undefined,
-  };
-
-  // Webhooks send this over as `milestone`, but the API uses `projectMilestone` and users model their Zaps off the API response to start
-  if (entity.milestone) {
-    entity.projectMilestone = entity.milestone;
-    delete entity.milestone;
+  const filters = [];
+  if ("priority" in variables) {
+    filters.push(`priority: { eq: $priority }`);
+  }
+  if ("statusId" in variables) {
+    filters.push(`state: { id: { eq: $statusId } }`);
+  }
+  if ("creatorId" in variables) {
+    filters.push(`creator: { id: { eq: $creatorId } }`);
+  }
+  if ("assigneeId" in variables) {
+    filters.push(`assignee: { id: { eq: $assigneeId } }`);
+  }
+  if ("labelId" in variables) {
+    filters.push(`labels: { id: { eq: $labelId } }`);
+  }
+  if ("projectId" in variables) {
+    filters.push(`project: { id: { eq: $projectId } }`);
+  }
+  if ("projectMilestoneId" in variables) {
+    filters.push(`projectMilestone: { id: { eq: $projectMilestoneId } }`);
   }
 
-  return [entity];
+  const response = await z.request({
+    url: "https://api.linear.app/graphql",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      authorization: bundle.authData.api_key,
+    },
+    body: {
+      query: `
+      query ZapierListIssues(
+        $after: String
+        $teamId: String!
+        ${"priority" in variables ? "$priority: Float" : ""}
+        ${"statusId" in variables ? "$statusId: ID" : ""}
+        ${"creatorId" in variables ? "$creatorId: ID" : ""}
+        ${"assigneeId" in variables ? "$assigneeId: ID" : ""}
+        ${"labelId" in variables ? "$labelId: ID" : ""}
+        ${"projectId" in variables ? "$projectId: ID" : ""}
+        ${"projectMilestoneId" in variables ? "$projectMilestoneId: ID" : ""}
+        $orderBy: PaginationOrderBy!
+      ) {
+        team(id: $teamId) {
+          issues(
+            first: 10
+            after: $after
+            orderBy: $orderBy
+            ${
+              filters.length > 0
+                ? `
+            filter: {
+              ${filters.join("\n              ")}
+            }`
+                : ""
+            }
+          ) {
+            nodes {
+              id
+              identifier
+              url
+              title
+              description
+              priority
+              estimate
+              dueDate
+              slaBreachesAt
+              slaStartedAt
+              createdAt
+              updatedAt
+              project {
+                id
+                name
+              }
+              projectMilestone {
+                id
+                name
+              }
+              creator {
+                id
+                name
+                email
+              }
+              assignee {
+                id
+                name
+                email
+              }
+              status: state {
+                id
+                name
+                type
+              }
+              parent {
+                id
+                identifier
+                url
+                title
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+      `,
+      variables,
+    },
+    method: "POST",
+  });
+
+  const data = (response.json as TeamIssuesResponse).data;
+  const issues = data.team.issues.nodes;
+
+  // Set cursor for pagination
+  if (data.team.issues.pageInfo.hasNextPage) {
+    await z.cursor.set(data.team.issues.pageInfo.endCursor);
+  }
+
+  return issues.map((issue) => ({
+    ...issue,
+    id: `${issue.id}-${issue[orderBy]}`,
+    issueId: issue.id,
+  }));
 };
 
-const operationBase = {
-  inputFields: [
-    {
-      required: true,
-      label: "Team",
-      key: "teamId",
-      helpText: "The team for the issue.",
-      dynamic: "team.id.name",
-      altersDynamicFields: true,
-    },
-    {
-      required: false,
-      label: "Status",
-      key: "statusId",
-      helpText: "The issue status.",
-      dynamic: "status.id.name",
-      altersDynamicFields: true,
-    },
-    {
-      required: false,
-      label: "Creator",
-      key: "creatorId",
-      helpText: "The user who created this issue.",
-      dynamic: "user.id.name",
-      altersDynamicFields: true,
-    },
-    {
-      required: false,
-      label: "Assignee",
-      key: "assigneeId",
-      helpText: "The assignee of this issue.",
-      dynamic: "user.id.name",
-      altersDynamicFields: true,
-    },
-    {
-      required: false,
-      label: "Priority",
-      key: "priority",
-      helpText: "The priority of the issue.",
-      choices: [
-        { value: "0", sample: "0", label: "No priority" },
-        { value: "1", sample: "1", label: "Urgent" },
-        { value: "2", sample: "2", label: "High" },
-        { value: "3", sample: "3", label: "Medium" },
-        { value: "4", sample: "4", label: "Low" },
-      ],
-    },
-    {
-      required: false,
-      label: "Label",
-      key: "labelId",
-      helpText: "Label which was assigned to the issue.",
-      dynamic: "label.id.name",
-      altersDynamicFields: true,
-    },
-    {
-      required: false,
-      label: "Project",
-      key: "projectId",
-      helpText: "Issue's project.",
-      dynamic: "project.id.name",
-      altersDynamicFields: true,
-    },
-    {
-      required: false,
-      label: "Project Milestone",
-      key: "projectMilestoneId",
-      helpText: "Issue's project milestone.",
-      dynamic: "project_milestone.id.name",
-      altersDynamicFields: true,
-    },
-  ],
-  type: "hook",
-  perform: getWebhookDataForIssue,
-  performUnsubscribe: unsubscribeHook,
-  performList: getIssueList(),
-  sample,
-};
-
-export const newIssueInstant = {
+const issue = {
   noun: "Issue",
-  key: "newIssueInstant",
+
+  operation: {
+    inputFields: [
+      {
+        required: true,
+        label: "Team",
+        key: "team_id",
+        helpText: "The team for the issue.",
+        dynamic: "team.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Status",
+        key: "status_id",
+        helpText: "The issue status.",
+        dynamic: "status.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Creator",
+        key: "creator_id",
+        helpText: "The user who created this issue.",
+        dynamic: "user.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Assignee",
+        key: "assignee_id",
+        helpText: "The assignee of this issue.",
+        dynamic: "user.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Priority",
+        key: "priority",
+        helpText: "The priority of the issue.",
+        choices: [
+          { value: "0", sample: "0", label: "No priority" },
+          { value: "1", sample: "1", label: "Urgent" },
+          { value: "2", sample: "2", label: "High" },
+          { value: "3", sample: "3", label: "Medium" },
+          { value: "4", sample: "4", label: "Low" },
+        ],
+      },
+      {
+        required: false,
+        label: "Label",
+        key: "label_id",
+        helpText: "Label which was assigned to the issue.",
+        dynamic: "label.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Project",
+        key: "project_id",
+        helpText: "Issue's project.",
+        dynamic: "project.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Project Milestone",
+        key: "project_milestone_id",
+        helpText: "Issue's project milestone.",
+        dynamic: "project_milestone.id.name",
+        altersDynamicFields: true,
+      },
+    ],
+    sample,
+  },
+};
+
+export const newIssue = {
+  ...issue,
+  key: "newIssue",
   display: {
     label: "New Issue",
     description: "Triggers when a new issue is created.",
+    hidden: true,
   },
   operation: {
-    ...operationBase,
-    performSubscribe: subscribeHook("create"),
+    ...issue.operation,
+    perform: buildIssueList("createdAt"),
+    canPaginate: true,
   },
 };
 
-export const updatedIssueInstant = {
-  noun: "Issue",
-  key: "updatedIssueInstant",
+export const updatedIssue = {
+  ...issue,
+  key: "updatedIssue",
   display: {
     label: "Updated Issue",
     description: "Triggers when an issue is updated.",
+    hidden: true,
   },
   operation: {
-    ...operationBase,
-    performSubscribe: subscribeHook("update"),
+    ...issue.operation,
+    perform: buildIssueList("updatedAt"),
+    canPaginate: true,
   },
 };

--- a/src/triggers/issueV2.ts
+++ b/src/triggers/issueV2.ts
@@ -1,0 +1,377 @@
+import { omitBy, pick } from "lodash";
+import { ZObject, Bundle } from "zapier-platform-core";
+import sample from "../samples/issue.json";
+import { unsubscribeHook } from "../handleWebhook";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
+import { fetchFromLinear } from "../fetchFromLinear";
+
+export interface IssueCommon {
+  id: string;
+  identifier: string;
+  url: string;
+  title: string;
+  description: string;
+  priority: string;
+  estimate?: number;
+  dueDate?: Date;
+  slaBreachesAt?: Date;
+  slaStartedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  project?: {
+    id: string;
+    name: string;
+  };
+  projectMilestone?: {
+    id: string;
+    name: string;
+  };
+  creator: {
+    id: string;
+    name: string;
+    email: string;
+  };
+  assignee?: {
+    id: string;
+    name: string;
+    email: string;
+  };
+  state: {
+    id: string;
+    name: string;
+    type: string;
+  };
+  parent?: {
+    id: string;
+    identifier: string;
+    url: string;
+    title: string;
+  };
+}
+
+interface IssueApi extends IssueCommon {
+  labels?: {
+    nodes: {
+      id: string;
+      color: string;
+      name: string;
+      parent?: {
+        id: string;
+      };
+    }[];
+  };
+}
+
+interface IssueWebhook extends IssueCommon {
+  labels?: {
+    id: string;
+    color: string;
+    name: string;
+    parentId?: string;
+  }[];
+}
+
+interface TeamIssuesResponse {
+  data: {
+    team: {
+      issues: {
+        nodes: IssueApi[];
+      };
+    };
+  };
+}
+
+const subscribeHook = (eventType: "create" | "update") => async (z: ZObject, bundle: Bundle) => {
+  if (!bundle.inputData.teamId) {
+    throw new z.errors.HaltedError("You must select a team");
+  }
+
+  const inputData =
+    bundle.inputData && Object.keys(bundle.inputData).length > 0
+      ? omitBy(
+          {
+            ...pick(bundle.inputData, [
+              "teamId",
+              "statusId",
+              "creatorId",
+              "assigneeId",
+              "labelId",
+              "projectId",
+              "projectMilestoneId",
+            ]),
+            priority: bundle.inputData.priority ? Number(bundle.inputData.priority) : undefined,
+          },
+          (v) => v === undefined
+        )
+      : undefined;
+
+  const data = {
+    url: bundle.targetUrl,
+    inputData,
+  };
+
+  const webhookType = eventType === "create" ? "createIssue" : "updateIssue";
+  return z
+    .request({
+      url: `https://client-api.linear.app/connect/zapier/subscribe/${webhookType}`,
+      method: "POST",
+      body: data,
+    })
+    .then((response) => response.data);
+};
+
+const getIssueList =
+  () =>
+  async (z: ZObject, bundle: Bundle): Promise<IssueWebhook[]> => {
+    if (!bundle.inputData.teamId) {
+      throw new z.errors.HaltedError("You must select a team");
+    }
+
+    const variables: Record<string, string | Number> = {};
+    const variableSchema: Record<string, string> = {};
+
+    variableSchema.teamId = "String!";
+    variables.teamId = bundle.inputData.teamId;
+
+    const filters: unknown[] = [];
+    if (bundle.inputData.priority) {
+      variableSchema.priority = "Float";
+      variables.priority = Number(bundle.inputData.priority);
+      filters.push({ priority: { eq: new VariableType("priority") } });
+    }
+    if (bundle.inputData.statusId) {
+      variableSchema.statusId = "ID";
+      variables.statusId = bundle.inputData.statusId;
+      filters.push({ state: { id: { eq: new VariableType("statusId") } } });
+    }
+    if (bundle.inputData.creatorId) {
+      variableSchema.creatorId = "ID";
+      variables.creatorId = bundle.inputData.creatorId;
+      filters.push({ creator: { id: { eq: new VariableType("creatorId") } } });
+    }
+    if (bundle.inputData.assigneeId) {
+      variableSchema.assigneeId = "ID";
+      variables.assigneeId = bundle.inputData.assigneeId;
+      filters.push({ assignee: { id: { eq: new VariableType("assigneeId") } } });
+    }
+    if (bundle.inputData.projectId) {
+      variableSchema.projectId = "ID";
+      variables.projectId = bundle.inputData.projectId;
+      filters.push({ project: { id: { eq: new VariableType("projectId") } } });
+    }
+    if (bundle.inputData.projectMilestoneId) {
+      variableSchema.projectMilestoneId = "ID";
+      variables.projectMilestoneId = bundle.inputData.projectMilestoneId;
+      filters.push({ projectMilestone: { id: { eq: new VariableType("projectMilestoneId") } } });
+    }
+    if (bundle.inputData.labelId) {
+      variableSchema.labelId = "ID";
+      variables.labelId = bundle.inputData.labelId;
+      filters.push({ labels: { id: { eq: new VariableType("labelId") } } });
+    }
+    const filter = { and: filters };
+
+    const jsonQuery = {
+      query: {
+        __variables: variableSchema,
+        team: {
+          __args: {
+            id: new VariableType("teamId"),
+          },
+          issues: {
+            __args: {
+              first: 10,
+              filter,
+            },
+            nodes: {
+              id: true,
+              identifier: true,
+              url: true,
+              title: true,
+              description: true,
+              priority: true,
+              estimate: true,
+              dueDate: true,
+              slaBreachesAt: true,
+              slaStartedAt: true,
+              createdAt: true,
+              updatedAt: true,
+              project: {
+                id: true,
+                name: true,
+              },
+              projectMilestone: {
+                id: true,
+                name: true,
+              },
+              creator: {
+                id: true,
+                name: true,
+                email: true,
+              },
+              assignee: {
+                id: true,
+                name: true,
+                email: true,
+              },
+              state: {
+                id: true,
+                name: true,
+                type: true,
+              },
+              parent: {
+                id: true,
+                identifier: true,
+                url: true,
+                title: true,
+              },
+              labels: {
+                nodes: {
+                  id: true,
+                  color: true,
+                  name: true,
+                  parent: {
+                    id: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const query = jsonToGraphQLQuery(jsonQuery);
+    const response = await fetchFromLinear(z, bundle, query, variables);
+    const data = (response.json as TeamIssuesResponse).data;
+    const issuesRaw = data.team.issues.nodes;
+    // We need to map the API schema to the webhook schema
+    return issuesRaw.map((issueRaw) => ({
+      ...issueRaw,
+      labels: issueRaw.labels?.nodes.map((label) => ({
+        id: label.id,
+        color: label.color,
+        name: label.name,
+        parentId: label.parent?.id,
+      })),
+    }));
+  };
+
+const getWebhookDataForIssue = (z: ZObject, bundle: Bundle) => {
+  const entity = {
+    ...bundle.cleanedRequest.data,
+    querystring: undefined,
+  };
+
+  // Webhooks send this over as `milestone`, but the API uses `projectMilestone` and users model their Zaps off the API response to start
+  if (entity.milestone) {
+    entity.projectMilestone = entity.milestone;
+    delete entity.milestone;
+  }
+
+  return [entity];
+};
+
+const operationBase = {
+  inputFields: [
+    {
+      required: true,
+      label: "Team",
+      key: "teamId",
+      helpText: "The team for the issue.",
+      dynamic: "team.id.name",
+      altersDynamicFields: true,
+    },
+    {
+      required: false,
+      label: "Status",
+      key: "statusId",
+      helpText: "The issue status.",
+      dynamic: "status.id.name",
+      altersDynamicFields: true,
+    },
+    {
+      required: false,
+      label: "Creator",
+      key: "creatorId",
+      helpText: "The user who created this issue.",
+      dynamic: "user.id.name",
+      altersDynamicFields: true,
+    },
+    {
+      required: false,
+      label: "Assignee",
+      key: "assigneeId",
+      helpText: "The assignee of this issue.",
+      dynamic: "user.id.name",
+      altersDynamicFields: true,
+    },
+    {
+      required: false,
+      label: "Priority",
+      key: "priority",
+      helpText: "The priority of the issue.",
+      choices: [
+        { value: "0", sample: "0", label: "No priority" },
+        { value: "1", sample: "1", label: "Urgent" },
+        { value: "2", sample: "2", label: "High" },
+        { value: "3", sample: "3", label: "Medium" },
+        { value: "4", sample: "4", label: "Low" },
+      ],
+    },
+    {
+      required: false,
+      label: "Label",
+      key: "labelId",
+      helpText: "Label which was assigned to the issue.",
+      dynamic: "label.id.name",
+      altersDynamicFields: true,
+    },
+    {
+      required: false,
+      label: "Project",
+      key: "projectId",
+      helpText: "Issue's project.",
+      dynamic: "project.id.name",
+      altersDynamicFields: true,
+    },
+    {
+      required: false,
+      label: "Project Milestone",
+      key: "projectMilestoneId",
+      helpText: "Issue's project milestone.",
+      dynamic: "project_milestone.id.name",
+      altersDynamicFields: true,
+    },
+  ],
+  type: "hook",
+  perform: getWebhookDataForIssue,
+  performUnsubscribe: unsubscribeHook,
+  performList: getIssueList(),
+  sample,
+};
+
+export const newIssueInstant = {
+  noun: "Issue",
+  key: "newIssueInstant",
+  display: {
+    label: "New Issue",
+    description: "Triggers when a new issue is created.",
+  },
+  operation: {
+    ...operationBase,
+    performSubscribe: subscribeHook("create"),
+  },
+};
+
+export const updatedIssueInstant = {
+  noun: "Issue",
+  key: "updatedIssueInstant",
+  display: {
+    label: "Updated Issue",
+    description: "Triggers when an issue is updated.",
+  },
+  operation: {
+    ...operationBase,
+    performSubscribe: subscribeHook("update"),
+  },
+};

--- a/src/triggers/projectUpdate.ts
+++ b/src/triggers/projectUpdate.ts
@@ -1,0 +1,176 @@
+import sample from "../samples/projectUpdate.json";
+import { ZObject, Bundle } from "zapier-platform-core";
+
+interface ProjectUpdatesResponse {
+  data: {
+    projectUpdates: {
+      nodes: {
+        id: string;
+        body: string;
+        diffMarkdown: string;
+        createdAt: Date;
+        updatedAt: Date;
+        project?: {
+          id: string;
+          name: string;
+        };
+        user: {
+          id: string;
+          name: string;
+          email: string;
+        };
+      }[];
+      pageInfo: {
+        hasNextPage: boolean;
+        endCursor: string;
+      };
+    };
+  };
+}
+
+const buildProjectUpdateList = (orderBy: "createdAt" | "updatedAt") => async (z: ZObject, bundle: Bundle) => {
+  const cursor = bundle.meta.page ? await z.cursor.get() : undefined;
+
+  const response = await z.request({
+    url: "https://api.linear.app/graphql",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      authorization: bundle.authData.api_key,
+    },
+    body: {
+      query: `
+      query ZapierListProjectUpdates(
+        $after: String
+        $teamId: ID
+        $projectId: ID
+        $userId: ID
+        $orderBy: PaginationOrderBy!
+      ) {
+        projectUpdates(
+          first: 10
+          after: $after
+          orderBy: $orderBy
+          filter: {
+            project: {
+              id: { eq: $projectId }
+              accessibleTeams: { id: { eq: $teamId } }
+            }
+            user: { id: { eq: $userId } }
+          }
+        ) {
+          nodes {
+            id
+            body
+            diffMarkdown
+            health
+            url
+            editedAt
+            createdAt
+            updatedAt
+            project {
+              id
+              name
+            }
+            user {
+              id
+              name
+              email
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+      `,
+      variables: {
+        after: cursor,
+        teamId: bundle.inputData.team_id,
+        projectId: bundle.inputData.project_id,
+        userId: bundle.inputData.user_id,
+        orderBy,
+      },
+    },
+    method: "POST",
+  });
+
+  const data = (response.json as ProjectUpdatesResponse).data;
+  const projectUpdates = data.projectUpdates.nodes;
+
+  // Set cursor for pagination
+  if (data.projectUpdates.pageInfo.hasNextPage) {
+    await z.cursor.set(data.projectUpdates.pageInfo.endCursor);
+  }
+
+  return projectUpdates.map((projectUpdate) => ({
+    ...projectUpdate,
+    id: `${projectUpdate.id}-${projectUpdate[orderBy]}`,
+    projectUpdateId: projectUpdate.id,
+  }));
+};
+
+const projectUpdate = {
+  noun: "Project Update",
+
+  operation: {
+    inputFields: [
+      {
+        required: false,
+        label: "Team",
+        key: "team_id",
+        helpText: "Limit to project updates from projects in this team.",
+        dynamic: "team.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Project",
+        key: "project_id",
+        helpText: "Project this update belongs to.",
+        dynamic: "project.id.name",
+        altersDynamicFields: true,
+      },
+      {
+        required: false,
+        label: "Creator",
+        key: "user_id",
+        helpText: "The user who created this project update.",
+        dynamic: "user.id.name",
+        altersDynamicFields: true,
+      },
+    ],
+    sample,
+  },
+};
+
+export const newProjectUpdate = {
+  ...projectUpdate,
+  key: "newProjectUpdate",
+  display: {
+    label: "New Project Update",
+    description: "Triggers when a new project update is created.",
+    hidden: true,
+  },
+  operation: {
+    ...projectUpdate.operation,
+    perform: buildProjectUpdateList("createdAt"),
+    canPaginate: true,
+  },
+};
+
+export const updatedProjectUpdate = {
+  ...projectUpdate,
+  key: "updatedProjectUpdate",
+  display: {
+    label: "Updated Project Update",
+    description: "Triggers when a project update is updated.",
+    hidden: true,
+  },
+  operation: {
+    ...projectUpdate.operation,
+    perform: buildProjectUpdateList("updatedAt"),
+    canPaginate: true,
+  },
+};


### PR DESCRIPTION
Reverts linear/linear-zapier#94

Apparently it is a breaking change on Zapier to remove old triggers, even if they have been hidden previously, so we can't get rid of the old triggers from the codebase 😕 

![CleanShot 2025-05-02 at 17 20 28](https://github.com/user-attachments/assets/87c4bdb1-ed46-4aa5-beb9-a9b1f75eb92a)
