### PR TITLE
Use refresh tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "4.8.6",
+  "version": "4.9.0",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -81,6 +81,22 @@ export const authentication = {
         "Content-Type": "application/x-www-form-urlencoded",
       },
     },
+    // Zapier will automatically refresh the access token when it expires
+    refreshAccessToken: {
+      method: "POST",
+      url: "https://api.linear.app/oauth/token",
+      body: {
+        refresh_token: "{{bundle.authData.refresh_token}}",
+        client_id: "{{process.env.CLIENT_ID}}",
+        client_secret: "{{process.env.CLIENT_SECRET}}",
+        grant_type: "refresh_token",
+      },
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    },
+    // Enable automatic token refresh on 401 errors
+    autoRefresh: true,
     scope: "read,write",
   },
 


### PR DESCRIPTION
Scoped to a new version to cleanly separate from the old behavior. Confirmed in local testing that zaps on old versions without refresh tokens do not break.

Towards USP-8499