### PR TITLE
Fix Zapier issue payloads and search errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.15.0
+
+- Added team details to issue trigger test data.
+- Added GraphQL error handling to the "Find Issues by Name" search action.
+
 ## 4.14.0
 
 - Added attachments (with metadata) to the issue searches and the issue trigger.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-zapier",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "description": "Linear's Zapier integration",
   "main": "index.js",
   "license": "MIT",

--- a/src/samples/issueInstant.json
+++ b/src/samples/issueInstant.json
@@ -1,0 +1,71 @@
+{
+  "id": "044a462c-1acd-4092-8e66-51e4d7c9c7ca",
+  "identifier": "SAMPLE-15",
+  "url": "https://linear.app/example/issue/SAMPLE-15",
+  "title": "Zapier sample",
+  "description": "More information about the issue",
+  "priority": 0,
+  "estimate": null,
+  "dueDate": null,
+  "slaBreachesAt": null,
+  "slaStartedAt": null,
+  "createdAt": "2022-10-27T21:20:59.199Z",
+  "updatedAt": "2022-10-27T21:20:59.199Z",
+  "teamId": "2b03b41f-4b55-4779-bd22-4786eb76e11f",
+  "team": {
+    "id": "2b03b41f-4b55-4779-bd22-4786eb76e11f",
+    "key": "SAMPLE",
+    "name": "Sample Team"
+  },
+  "project": {
+    "id": "04a48f13-c39f-4522-85bb-a17225cbfdf3",
+    "name": "My Project"
+  },
+  "projectMilestone": {
+    "id": "84cb5a2f-4b84-4e90-a06a-d0b38f9ac2dd",
+    "name": "V1"
+  },
+  "creator": {
+    "id": "45920bc2-c4be-434f-b588-f422155667b5",
+    "name": "Zapier User",
+    "email": "creator@example.com"
+  },
+  "assignee": {
+    "id": "8a225115-706e-4389-87da-e687b9b5ae76",
+    "name": "Zapier User 2",
+    "email": "assignee@example.com"
+  },
+  "status": {
+    "id": "e6d2eb84-b03b-4827-9230-94b0a1099419",
+    "name": "In Progress",
+    "type": "started"
+  },
+  "parent": {
+    "id": "e6d2eb84-b03b-4827-9230-94b0a1099419",
+    "identifier": "SAMPLE-10",
+    "url": "https://linear.app/example/issue/SAMPLE-10",
+    "title": "Zapier parent sample"
+  },
+  "addedLabels": [],
+  "attachments": {
+    "nodes": [
+      {
+        "id": "2d08eab7-8f8c-44e4-b3cd-4a5e6297fcc4",
+        "title": "Question #1174",
+        "subtitle": "Testing screenshots",
+        "url": "https://example.zendesk.com/tickets/1174",
+        "source": { "type": "zendesk" },
+        "sourceType": "zendesk",
+        "metadata": {
+          "id": 1174,
+          "title": "Testing screenshots",
+          "priority": "normal",
+          "attributes": [
+            { "name": "Type", "value": "Question" },
+            { "name": "Priority", "value": "normal" }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/searches/issueByName.ts
+++ b/src/searches/issueByName.ts
@@ -14,7 +14,13 @@ interface IssueByNameResponse {
     issues: {
       nodes: IssueByNameApi[];
     };
-  };
+  } | null;
+  errors?: {
+    message: string;
+    extensions?: {
+      userPresentableMessage?: string;
+    };
+  }[];
 }
 
 interface IssueByNameApi extends IssueCommon {
@@ -130,8 +136,18 @@ const getIssuesByName = async (z: ZObject, bundle: Bundle<IssueByNameInput>) => 
   });
 
   const response = await fetchFromLinear(z, bundle, query, variables);
-  const data = (response.json as IssueByNameResponse).data;
-  return data.issues.nodes;
+  const body = response.json as IssueByNameResponse;
+  const firstError = body.errors?.[0];
+
+  if (firstError) {
+    throw new z.errors.Error(
+      firstError.extensions?.userPresentableMessage ?? firstError.message,
+      "request_execution_failed",
+      400
+    );
+  }
+
+  return body.data?.issues.nodes ?? [];
 };
 
 export const findIssueByName = {

--- a/src/test/searches/issueByName.test.js
+++ b/src/test/searches/issueByName.test.js
@@ -86,6 +86,62 @@ describe("searches.issue_by_name", () => {
     });
   });
 
+  it("returns an empty array when Linear returns no issue data", async () => {
+    const requestMock = jest.fn().mockResolvedValue({
+      json: { data: null },
+    });
+
+    const results = await appTester(
+      (z, bundle) => {
+        z.request = requestMock;
+        return perform(z, bundle);
+      },
+      {
+        authData: {
+          api_key: "test-linear-api-key",
+        },
+        inputData: {
+          name: "Setup SSO",
+        },
+      }
+    );
+
+    expect(results).toEqual([]);
+  });
+
+  it("throws the user-presentable message for GraphQL errors", async () => {
+    const requestMock = jest.fn().mockResolvedValue({
+      json: {
+        data: null,
+        errors: [
+          {
+            message: "Internal server error",
+            extensions: {
+              userPresentableMessage: "Something went wrong on our end.",
+            },
+          },
+        ],
+      },
+    });
+
+    await expect(
+      appTester(
+        (z, bundle) => {
+          z.request = requestMock;
+          return perform(z, bundle);
+        },
+        {
+          authData: {
+            api_key: "test-linear-api-key",
+          },
+          inputData: {
+            name: "Setup SSO",
+          },
+        }
+      )
+    ).rejects.toThrow("Something went wrong on our end.");
+  });
+
   it("adds teamId to query variables when teamId is provided", async () => {
     const requestMock = jest.fn().mockResolvedValue({
       json: issuesByNameResponse,

--- a/src/test/triggers/newIssueInstant.test.js
+++ b/src/test/triggers/newIssueInstant.test.js
@@ -1,0 +1,87 @@
+const zapier = require("zapier-platform-core");
+const App = require("../../../index");
+
+const appTester = zapier.createAppTester(App);
+const newIssueInstant = App.triggers.newIssueInstant;
+const newIssueLegacy = App.triggers.newIssue;
+
+describe("triggers.newIssueInstant", () => {
+  it("uses a team sample without changing the legacy sample", () => {
+    expect(newIssueInstant.operation.sample).toEqual(
+      expect.objectContaining({
+        teamId: "2b03b41f-4b55-4779-bd22-4786eb76e11f",
+        team: {
+          id: "2b03b41f-4b55-4779-bd22-4786eb76e11f",
+          key: "SAMPLE",
+          name: "Sample Team",
+        },
+      })
+    );
+    expect(newIssueInstant.operation.sample.attachments).toEqual(newIssueLegacy.operation.sample.attachments);
+    expect(newIssueLegacy.operation.sample).not.toHaveProperty("teamId");
+    expect(newIssueLegacy.operation.sample).not.toHaveProperty("team");
+  });
+
+  it("includes the team in polling test data", async () => {
+    const requestMock = jest.fn().mockResolvedValue({
+      json: {
+        data: {
+          team: {
+            id: "team-id",
+            key: "ENG",
+            name: "Engineering",
+            issues: {
+              nodes: [
+                {
+                  id: "issue-id",
+                  identifier: "ENG-123",
+                  url: "https://linear.app/example/issue/ENG-123",
+                  title: "Test issue",
+                  description: "Test description",
+                  priority: 0,
+                  createdAt: "2026-07-31T00:00:00.000Z",
+                  updatedAt: "2026-07-31T00:00:00.000Z",
+                  creator: {
+                    id: "creator-id",
+                    name: "Creator",
+                    email: "creator@example.com",
+                  },
+                  state: {
+                    id: "state-id",
+                    name: "Backlog",
+                    type: "backlog",
+                  },
+                  labels: { nodes: [] },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const [issue] = await appTester(
+      (z, bundle) => {
+        z.request = requestMock;
+        return newIssueInstant.operation.performList(z, bundle);
+      },
+      {
+        authData: { api_key: "test-linear-api-key" },
+        inputData: { teamId: "team-id" },
+      }
+    );
+
+    const compactQuery = requestMock.mock.calls[0][0].body.query.replace(/\s/g, "");
+    expect(compactQuery).toContain("team(id:$teamId){idkeynameissues");
+    expect(issue).toEqual(
+      expect.objectContaining({
+        teamId: "team-id",
+        team: {
+          id: "team-id",
+          key: "ENG",
+          name: "Engineering",
+        },
+      })
+    );
+  });
+});

--- a/src/triggers/issue.ts
+++ b/src/triggers/issue.ts
@@ -1,6 +1,6 @@
 import { omitBy, pick } from "lodash";
 import { ZObject, Bundle } from "zapier-platform-core";
-import sample from "../samples/issue.json";
+import sample from "../samples/issueInstant.json";
 import { unsubscribeHook } from "../handleWebhook";
 import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
 import { fetchFromLinear, LinearGraphQLVariables } from "../fetchFromLinear";
@@ -60,6 +60,12 @@ export interface IssueCommon {
   };
 }
 
+interface IssueTeam {
+  id: string;
+  key: string;
+  name: string;
+}
+
 interface IssueApi extends IssueCommon {
   labels?: {
     nodes: {
@@ -74,6 +80,8 @@ interface IssueApi extends IssueCommon {
 }
 
 interface IssueWebhook extends IssueCommon {
+  teamId: string;
+  team: IssueTeam;
   labels?: {
     id: string;
     color: string;
@@ -84,7 +92,7 @@ interface IssueWebhook extends IssueCommon {
 
 interface TeamIssuesResponse {
   data: {
-    team: {
+    team: IssueTeam & {
       issues: {
         nodes: IssueApi[];
       };
@@ -189,6 +197,9 @@ const getIssueList =
           __args: {
             id: new VariableType("teamId"),
           },
+          id: true,
+          key: true,
+          name: true,
           issues: {
             __args: {
               first: 10,
@@ -269,6 +280,12 @@ const getIssueList =
     // We need to map the API schema to the webhook schema
     return issuesRaw.map((issueRaw) => ({
       ...issueRaw,
+      teamId: data.team.id,
+      team: {
+        id: data.team.id,
+        key: data.team.key,
+        name: data.team.name,
+      },
       labels: issueRaw.labels?.nodes.map((label) => ({
         id: label.id,
         color: label.color,


### PR DESCRIPTION
## Summary

Polling did not select the team fields returned by live issue webhooks.

- Include `teamId` and `team` in issue trigger test data.
- Handle null and error responses in the issue-by-name search.
- Bump the app to 4.15.0.

## Validation

- 20 tests passed
- Zapier validation: 34 passed, 0 failed
